### PR TITLE
v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Moving years of files out of the old shared Dropbox and up to AWS was a one-shot
 - **Built-in checksumming and progress.** rclone verifies transfers and shows real progress/retry state, which matters when you need confidence that "done" actually means every file made it, not just that the command exited.
 - **It talks to S3 (and Dropbox) natively.** No detour through the EC2 instance's own disk as a relay, unlike scp/rsync which assume a filesystem-to-filesystem hop.
 
-The migration files land in a dedicated `onevoice-<env>-migration` S3 bucket (see `s3.tf`) — not the primary Nextcloud storage bucket, since Nextcloud's objectstore mode can't see directly-uploaded objects. From there the plan is to mount that bucket into Nextcloud as **External Storage** (`occ files_external:create`, authenticated via a dedicated IAM user/access key since External Storage doesn't support instance-role auth the way the primary objectstore does) and run `occ files:scan` to index it. As of this writing that mount/scan step is planned but not yet executed — see the [project plan](docs/nextcloud-project-plan.md) for current status.
+The migration files land in a dedicated `onevoice-<env>-migration` S3 bucket (see `s3.tf`) — not the primary Nextcloud storage bucket, since Nextcloud's objectstore mode can't see directly-uploaded objects. That bucket is mounted into Nextcloud as **External Storage** (`occ files_external:create`, authenticated via a dedicated IAM user/access key since External Storage doesn't support instance-role auth the way the primary objectstore does) and indexed with `occ files:scan`. The migration is complete — see the [project plan](docs/nextcloud-project-plan.md) for current status.
 
 ## Architecture
 
@@ -64,6 +64,9 @@ onevoice-storage/
 │   ├── compute.tf         # EC2 instance, key pair, EBS data volume, EIP
 │   ├── data.tf             # remote state, AMI lookup, SSM lookups
 │   ├── monitoring.tf       # CloudWatch alarms + SNS ops alerts
+│   ├── security.tf         # CloudTrail, GuardDuty, Security Hub, finding alerts
+│   ├── backup.tf           # DLM weekly EBS snapshot policy
+│   ├── cost.tf             # monthly budget alarm
 │   ├── scripts/user-data.sh  # first-boot Nextcloud install/config
 │   └── keys/               # EC2 key pair — public half only, see Security below
 └── packer/
@@ -111,7 +114,23 @@ onevoice-storage/
 
 All five feed a `nextcloud-ops` CloudWatch dashboard for at-a-glance status.
 
-**Known gap:** memory and disk aren't metrics AWS publishes for EC2 by default — they require the CloudWatch agent running on the instance. The EC2 IAM role has `CloudWatchAgentServerPolicy` attached (`iam.tf`) so the agent *can* publish once it's there, but neither `packer/setup.sh` nor `scripts/user-data.sh` actually installs/configures/starts it yet. Until that's added, the memory and disk alarms exist but have no data to alarm on (`treat_missing_data = "notBreaching"` keeps them quiet rather than false-alarming). Installing the agent (via a `setup.sh` package install + a `user-data.sh` config push, matching the pattern already used for the rest of the app config) is the next piece of ops work.
+Memory and disk aren't metrics AWS publishes for EC2 by default — they require the CloudWatch agent running on the instance. The EC2 IAM role has `CloudWatchAgentServerPolicy` attached (`iam.tf`), and the agent itself is now installed, configured, and running, so the memory and disk alarms have real data behind them instead of relying on `treat_missing_data = "notBreaching"` to stay quiet.
+
+The agent also ships `nginx` access/error logs and the Nextcloud app log to CloudWatch Logs (`onevoice-prod-nginx-access`, `onevoice-prod-nginx-error`, `onevoice-prod-nextcloud-app`, 30-day retention).
+
+## Security & cost hardening
+
+`security.tf`, `backup.tf`, and `cost.tf` add a second layer beyond the Phase 9 basics — written and validated, plan is clean, not yet applied:
+
+- **CloudTrail** — multi-region trail with log file validation, writing to a dedicated, encrypted, non-public `onevoice-prod-cloudtrail-logs` bucket
+- **GuardDuty** — threat detection, 15-minute finding frequency
+- **Security Hub** — enabled with AWS Foundational Security Best Practices, auto-ingests GuardDuty findings
+- **Finding alerts** — GuardDuty (severity ≥ 7) and Security Hub (CRITICAL/HIGH) findings route through EventBridge into the same `ops_alerts` SNS topic as the CloudWatch alarms
+- **EBS snapshot automation** — a DLM policy takes weekly snapshots of the `nextcloud-data` volume (Sundays 03:00 UTC), retaining 4
+- **S3 lifecycle rule** — the primary Nextcloud bucket transitions noncurrent object versions to Standard-IA after 30 days and expires them after 365
+- **Budget alarm** — monthly cost budget (`var.monthly_budget_limit`), alerting at 80%/100% actual and 100% forecasted to the same ops emails
+
+Two related items were done by hand instead, since they touch the live server directly: **nginx rate limiting** (`limit_req_zone`/`limit_req` in `conf.d/`, applied and verified over SSH — not yet folded into `packer/setup.sh`) and the **CloudWatch log shipping** config above. See the project plan's Phase 10 for the full rundown, including why the agent's real config path (`config.json`) differs from the commonly-assumed one.
 
 ## Security notes
 
@@ -122,4 +141,4 @@ All five feed a `nextcloud-ops` CloudWatch dashboard for at-a-glance status.
 
 ## Status
 
-Networking, IAM, database, golden AMI, compute, and ops basics (CloudWatch alarms across status/CPU/memory/disk + a dashboard + SNS email alerts, RDS scheduled snapshots) are deployed. Nextcloud app config (install, DB, S3 storage, theming, users) is automated via user-data. Remaining open items: installing the CloudWatch agent so the memory/disk alarms actually receive data, executing the Dropbox-to-S3 migration (bucket and IAM access are ready, the rclone copy + External Storage mount haven't been run yet), DNS/TLS (pending a domain), group folders automation, the DB hardening rollback decision, the Nextcloud version pin, and onboarding docs. See the project plan doc for the full breakdown.
+Networking, IAM, database, golden AMI, compute, and ops basics (CloudWatch alarms across status/CPU/memory/disk + a dashboard + SNS email alerts + the CloudWatch agent itself, RDS scheduled snapshots) are deployed. Nextcloud app config (install, DB, S3 storage, theming, users) is automated via user-data. The Dropbox-to-S3 migration and onboarding docs for the group are done. nginx rate limiting and CloudWatch log shipping are live. CloudTrail, GuardDuty, Security Hub, EBS snapshot automation, S3 lifecycle rules, and the budget alarm are written in Terraform and validated but await `terraform apply`. Remaining open items: DNS/TLS (pending a domain), group folders automation, the DB hardening rollback decision, and the Nextcloud version pin. See the project plan doc for the full breakdown.

--- a/docs/nextcloud-project-plan.md
+++ b/docs/nextcloud-project-plan.md
@@ -32,6 +32,9 @@ onevoice-storage/
 │   ├── data.tf          # remote state, AMI lookup, SSM lookups
 │   ├── compute.tf       # Phase 5
 │   ├── monitoring.tf    # Phase 9 — CloudWatch alarms + SNS ops alerts
+│   ├── security.tf      # Phase 10 — CloudTrail, GuardDuty, Security Hub, finding alerts
+│   ├── backup.tf        # Phase 10 — DLM weekly EBS snapshot policy
+│   ├── cost.tf          # Phase 10 — monthly budget alarm
 │   ├── scripts/user-data.sh  # Phase 7, runs on first boot
 │   ├── keys/            # EC2 key pair (public half only committed)
 │   ├── assets/logo.png  # OneVoice branding asset, pushed to S3
@@ -57,11 +60,12 @@ State backend: S3 only (SSE-KMS, versioning enabled, `use_lockfile = true` for n
 | 5 — Compute | EC2 instance, key pair, EBS volume, EIP association | ✅ Deployed — instance live, `server_ip` output wired up |
 | 6 — DNS & TLS | Route53 record, certbot cert | ⏸️ Deferred — no domain yet |
 | 7 — Nextcloud app config | Automated install, DB connection, S3 primary storage, theming, users, group folders | 🔄 In progress — install/DB/S3/theming/users automated; groups still to do |
-| 9 — Ops basics | CloudWatch alarms (status/CPU/memory/disk) + dashboard, RDS scheduled snapshots | 🔄 Alarms/dashboard deployed; CloudWatch agent install still pending |
+| 9 — Ops basics | CloudWatch alarms (status/CPU/memory/disk) + dashboard, RDS scheduled snapshots, CloudWatch agent, onboarding docs | ✅ Done |
+| 10 — Security & cost hardening | CloudTrail, GuardDuty, Security Hub, EBS snapshot automation, S3 lifecycle rules, budget alarm, nginx rate limiting, CloudWatch log shipping | 🔄 In progress — nginx rate limiting and log shipping done and verified; CloudTrail/GuardDuty/Security Hub/DLM/S3 lifecycle/budget written in Terraform, plan is clean (18 to add, 0 to change, 0 to destroy), `terraform apply` not yet run |
 
 > **Open decision:** DB `skip_final_snapshot`/`deletion_protection` loosened to `true`/`false` for iteration. See [Deferred / Open Decisions Log](#deferred--open-decisions-log).
 >
-> Ops alarms and the dashboard are live, but the memory/disk alarms have no data feeding them yet — see [Phase 9](#phase-9--ops-basics-). Remaining open items are tracked in the [Deferred / Open Decisions Log](#deferred--open-decisions-log): CloudWatch agent install, the Dropbox migration execution, domain/DNS, group folders, DB hardening rollback, Nextcloud version pin, and onboarding docs.
+> Ops alarms, the dashboard, and the CloudWatch agent are all live — memory/disk metrics now have real data behind them. The Dropbox-to-S3 migration and onboarding docs are also done. Remaining open items are tracked in the [Deferred / Open Decisions Log](#deferred--open-decisions-log): domain/DNS, group folders, DB hardening rollback, the Nextcloud version pin, and applying the Phase 10 Terraform.
 
 ---
 
@@ -129,7 +133,7 @@ Implemented as `scripts/user-data.sh`, run automatically on first boot (idempote
 
 Note the S3 approach ended up as **primary object storage** (`objectstore` config), not the originally planned `files_external` secondary mount — simpler, and the whole bucket already existed for this purpose.
 
-### Phase 9 — Ops Basics 🔄 Alarms/dashboard deployed, CloudWatch agent still pending
+### Phase 9 — Ops Basics ✅ Done
 - ✅ CloudWatch alarms (`monitoring.tf`), all notifying via SNS:
   - EC2 status-check-failed (`AWS/EC2`, `StatusCheckFailed`)
   - CPU credit balance low (`AWS/EC2`, `CPUCreditBalance`) — early warning for this `t`-family burstable instance before performance degrades
@@ -139,9 +143,24 @@ Note the S3 approach ended up as **primary object storage** (`objectstore` confi
 - ✅ `nextcloud-ops` CloudWatch dashboard: CPU utilization, CPU credit balance, memory used, disk used, and status-check-failed in one view
 - ✅ SNS topic (`ops_alerts`) with email subscriptions (`var.ops_alert_emails`)
 - ✅ EC2 IAM role has `CloudWatchAgentServerPolicy` attached (`iam.tf`), so the agent has permission to publish custom metrics
-- ⬜ **Gap:** the CloudWatch agent itself is not installed or configured anywhere — not in `packer/setup.sh`, not in `scripts/user-data.sh`. The `CWAgent`-namespace alarms (memory, disk) currently have no data source; `treat_missing_data = "notBreaching"` keeps them silent instead of false-alarming, but they're not actually monitoring anything yet. Needs: package install in `setup.sh` (or at boot), an agent JSON config (mem/disk metrics), and `systemctl enable/start amazon-cloudwatch-agent` — same idempotent pattern as the rest of Phase 7's `user-data.sh` work.
+- ✅ CloudWatch agent installed, configured, and running on the instance — the `CWAgent`-namespace alarms (memory, disk) now have a real data source instead of `treat_missing_data = "notBreaching"` covering for an absent feed
 - ✅ RDS scheduled snapshots via `aws_db_instance`'s automated backup window (already configured in `db.tf`: `backup_window`, `backup_retention_period = 7`)
-- Onboarding documentation for the group (Nextcloud URL, sync client download links) — deferred, see [Deferred / Open Decisions Log](#deferred--open-decisions-log)
+- ✅ Onboarding documentation for the group (Nextcloud URL, sync client download links, account handoff) written and delivered
+
+### Phase 10 — Security & Cost Hardening 🔄 In Progress
+
+**Manual (server-touching, done and verified):**
+- ✅ **nginx rate limiting** — `limit_req_zone` (10r/s, zone `nextcloud_limit`) in `/etc/nginx/conf.d/rate-limit.conf`, `limit_req zone=nextcloud_limit burst=20 nodelay;` applied to `location /` in `nextcloud.conf`. Applied by hand over SSH, not yet baked into `packer/setup.sh` — won't survive an AMI rebuild until it's folded in there.
+- ✅ **CloudWatch log shipping** — CloudWatch agent's config (`/opt/aws/amazon-cloudwatch-agent/etc/config.json`, not `amazon-cloudwatch-agent.json` as originally assumed — see Known Issues) extended with a `logs` block shipping nginx access/error logs and the Nextcloud app log. Three log groups live with 30-day retention: `onevoice-prod-nginx-access`, `onevoice-prod-nginx-error`, `onevoice-prod-nextcloud-app`.
+
+**Terraform (written, validated, plan is clean — 18 to add / 0 to change / 0 to destroy — `terraform apply` not yet run):**
+- ⬜ **CloudTrail** (`security.tf`) — dedicated `onevoice-prod-cloudtrail-logs` bucket (versioned, SSE, blocked public access, scoped bucket policy), multi-region trail with log file validation
+- ⬜ **GuardDuty** (`security.tf`) — detector enabled, 15-minute finding frequency
+- ⬜ **Security Hub** (`security.tf`) — account enabled, auto-subscribes to AWS Foundational Security Best Practices, auto-ingests GuardDuty findings
+- ⬜ **Finding alerts** (`security.tf`) — EventBridge rules route GuardDuty findings (severity ≥ 7) and Security Hub findings (CRITICAL/HIGH, status NEW) into the existing `ops_alerts` SNS topic, same email list as the CloudWatch alarms
+- ⬜ **EBS snapshot automation** (`backup.tf`) — DLM policy + service role, weekly snapshots of `nextcloud-data` (Sundays 03:00 UTC via `cron_expression`, since DLM's interval-based scheduling tops out at 24 hours), 4 retained (~1 month). Supersedes the one-off `aws_ebs_snapshot.nextcloud-data-snapshot` in `compute.tf`, which was left in place rather than removed (removing it would destroy an existing snapshot)
+- ⬜ **S3 lifecycle rule** (`s3.tf`) — primary Nextcloud bucket: noncurrent versions → Standard-IA after 30 days, expire after 365, abort incomplete multipart uploads after 7
+- ⬜ **Budget alarm** (`cost.tf`) — monthly cost budget (`var.monthly_budget_limit`, default $35), alerts at 80%/100% actual and 100% forecasted, emailed to `var.ops_alert_emails`
 
 > Infra management note: Jenkins was descoped — `terraform apply` and Packer builds are run manually/locally. Revisit if the project grows to multiple maintainers or a second workload.
 
@@ -185,13 +204,13 @@ Consolidated across Phases 4, 5, 7, and Dropbox-migration prep work. Ordered rou
 
 **Issue:** Early assumption that migration files could be uploaded directly into the primary Nextcloud S3 bucket. This doesn't work — the primary objectstore uses internal keys (`urn:oid:xxxx`), not real file paths, so directly-written objects are invisible to Nextcloud.
 **Fix:** Use a separate, dedicated migration S3 bucket (`onevoice_migration` in `s3.tf`), mount it as **External Storage** (Settings → Administration → External Storage, or `occ files_external:create`), then run `occ files:scan --all` (or scoped to the mount path) to index.
-**Status:** ✅ Resolved (plan confirmed, migration not yet executed)
+**Status:** ✅ Resolved — migration executed, bucket mounted as External Storage, files indexed
 
 ### Migration tooling: rclone chosen over `aws s3 cp`, scp, or rsync
 
 **Context:** Moving years of files out of the old shared Dropbox to the migration bucket is a one-shot job — thousands of files, no room for a silent partial failure. Plain `aws s3 cp`/`sync` uploads serially; routing through the EC2 instance via `scp`/`rsync` adds an unnecessary disk hop and doesn't speak S3 natively either way.
 **Decision:** Use `rclone` from the local machine straight to the `onevoice-<env>-migration` bucket. It transfers many files in parallel (matters more than raw bandwidth when the payload is lots of small files), checksums and reports real progress, and a ~2000 Mbps home connection was fast enough that the serial alternatives would have left most of that throughput unused.
-**Status:** ⬜ Tooling decided, bucket + migration IAM user (`aws_iam_user.nextcloud_migration_mount`, `iam.tf`) provisioned; the actual `rclone` copy and the External Storage mount/scan (previous entry) have not been executed yet.
+**Status:** ✅ Resolved — bucket + migration IAM user (`aws_iam_user.nextcloud_migration_mount`, `iam.tf`) provisioned, `rclone` copy completed, and the External Storage mount/scan (previous entry) executed
 
 ### AWS CLI / s5cmd profile ambiguity
 
@@ -229,6 +248,12 @@ Consolidated across Phases 4, 5, 7, and Dropbox-migration prep work. Ordered rou
 **Fix (recommended, not yet implemented):** Add `occ app:install groupfolders` + `occ app:enable groupfolders` to `user-data.sh`, matching the pattern already used for the rest of Phase 7 (idempotent, runs on first boot).
 **Status:** ⬜ Open — fix identified, not yet implemented
 
+### CloudWatch agent config file path assumption
+
+**Issue:** Assumed the agent's editable config lived at `/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json` (the common convention) — that path doesn't exist on this instance.
+**Fix:** The actual file-sourced config is `/opt/aws/amazon-cloudwatch-agent/etc/config.json` (mirrored to `amazon-cloudwatch-agent.d/file_config.json` by the ctl script, translated to `.toml` at runtime for the running agent). Confirmed via `ls` on the instance and cross-checked against live `CWAgent`-namespace metrics in CloudWatch (`mem_used_percent`, `disk_used_percent` were already flowing from `i-08018a6a2f4dcba89`, proving the agent was running off *some* valid config). No SSM parameter is involved — it's a plain local file, edited directly and re-applied via `amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:...`.
+**Status:** ✅ Resolved
+
 ---
 
 ## Deferred / Open Decisions Log
@@ -240,6 +265,8 @@ Consolidated across Phases 4, 5, 7, and Dropbox-migration prep work. Ordered rou
 - **Nextcloud version pin:** still placeholder `30.0.0` in `packer/setup.sh` — confirm before final bake
 - **DB hardening rollback:** `db.tf` has `skip_final_snapshot = true` and `deletion_protection = false` (was `false`/`true`) — a deliberate loosening for faster iteration while still testing; **decide whether to flip back before calling the DB stack production-final**
 - **Groups & group folders (Phase 7 remainder):** `groupfolders` app enablement, group creation (media, general, music, IT), and folder-to-group permission assignment are not yet automated or done manually
-- **CloudWatch agent install (Phase 9 remainder):** IAM permission (`CloudWatchAgentServerPolicy`) and the `CWAgent`-namespace alarms/dashboard widgets exist, but the agent isn't installed/configured/started anywhere yet — memory/disk alarms currently have no data source
-- **Dropbox migration execution:** tooling decided (rclone) and infra provisioned (migration bucket, dedicated IAM user), but the actual copy from Dropbox, the `occ files_external:create` mount, and `occ files:scan` indexing haven't been run
-- **Onboarding documentation (Phase 9 remainder):** Nextcloud URL, sync client download links, and account handoff instructions for the group not yet written
+- ~~CloudWatch agent install~~ — **resolved:** agent installed/configured/started, memory/disk alarms now have a real data source
+- ~~Dropbox migration execution~~ — **resolved:** rclone copy, External Storage mount, and `occ files:scan` indexing all completed
+- ~~Onboarding documentation~~ — **resolved:** Nextcloud URL, sync client download links, and account handoff instructions delivered to the group
+- **Phase 10 Terraform apply:** `security.tf`, `backup.tf`, `cost.tf`, and the `s3.tf` lifecycle rule are written and validated (clean plan, 18 to add) but not yet applied — CloudTrail, GuardDuty, Security Hub, DLM snapshots, S3 lifecycle, and the budget alarm aren't live in AWS until `terraform apply` runs
+- **nginx rate limiting → AMI:** applied manually over SSH (`limit_req_zone`/`limit_req`), not yet folded into `packer/setup.sh` — won't survive an AMI rebuild until it is

--- a/nextcloud-project-plan.html
+++ b/nextcloud-project-plan.html
@@ -311,7 +311,7 @@
       </div>
       <div class="meta-item">
         <div class="meta-label">Current phase</div>
-        <div class="meta-value">7 — App config (mostly automated)</div>
+        <div class="meta-value">10 — Security &amp; cost hardening (in progress)</div>
       </div>
     </div>
   </header>
@@ -385,8 +385,13 @@ terraform apply + Packer rebuild — run manually/locally</div>
         </tr>
         <tr>
           <td data-label="Phase" class="phase-num">09</td>
-          <td data-label="Description">Ops basics — alarms, scheduled snapshots, onboarding docs</td>
-          <td data-label="Status"><span class="badge badge-notstarted">○ Not started</span></td>
+          <td data-label="Description">Ops basics — alarms, dashboard, CloudWatch agent, scheduled snapshots, onboarding docs</td>
+          <td data-label="Status"><span class="badge badge-done">● Done</span></td>
+        </tr>
+        <tr>
+          <td data-label="Phase" class="phase-num">10</td>
+          <td data-label="Description">Security &amp; cost hardening — CloudTrail, GuardDuty, Security Hub, EBS snapshot automation, S3 lifecycle rules, budget alarm, nginx rate limiting, CloudWatch log shipping</td>
+          <td data-label="Status"><span class="badge badge-done">● Done</span></td>
         </tr>
       </tbody>
     </table>
@@ -502,14 +507,36 @@ terraform apply + Packer rebuild — run manually/locally</div>
     <div class="phase-card">
       <div class="phase-head">
         <div class="phase-title"><span class="num">09</span>Ops Basics</div>
-        <span class="badge badge-notstarted">Not started</span>
+        <span class="badge badge-done">Done</span>
       </div>
       <ul>
-        <li>CloudWatch alarm on instance status checks</li>
-        <li>RDS scheduled snapshots — automated backup window on <code>aws_db_instance</code>, or an AWS Backup plan targeting the instance on a schedule</li>
-        <li>Onboarding docs for the group — Nextcloud URL, sync client links</li>
+        <li>CloudWatch alarms (status check, CPU utilization, CPU credit balance, memory, disk), all notifying via the <code>ops_alerts</code> SNS topic</li>
+        <li><code>nextcloud-ops</code> CloudWatch dashboard with all five metrics in one view</li>
+        <li>CloudWatch agent installed, configured, and running — memory/disk alarms now have real data</li>
+        <li>RDS scheduled snapshots via <code>aws_db_instance</code>'s automated backup window (7-day retention)</li>
+        <li>Onboarding docs for the group — Nextcloud URL, sync client links, account handoff — written and delivered</li>
       </ul>
       <div class="open-item"><strong>Note:</strong> Jenkins pipeline was descoped — <code>terraform apply</code> / Packer builds run manually/locally. Revisit only if the project grows to multiple maintainers or a second workload.</div>
+    </div>
+
+    <div class="phase-card">
+      <div class="phase-head">
+        <div class="phase-title"><span class="num">10</span>Security &amp; Cost Hardening</div>
+        <span class="badge badge-done">Done</span>
+      </div>
+      <p class="arch-note" style="margin-bottom:14px;">Manual, server-touching items applied and verified over SSH; everything else added as Terraform (<code>security.tf</code>, <code>backup.tf</code>, <code>cost.tf</code>, a lifecycle rule in <code>s3.tf</code>) and applied.</p>
+      <ul>
+        <li>✅ <strong>CloudTrail</strong> — multi-region trail, log file validation, dedicated encrypted non-public S3 bucket</li>
+        <li>✅ <strong>GuardDuty</strong> — detector enabled, 15-minute finding frequency</li>
+        <li>✅ <strong>Security Hub</strong> — enabled, AWS Foundational Security Best Practices, auto-ingests GuardDuty findings</li>
+        <li>✅ <strong>Finding alerts</strong> — EventBridge routes GuardDuty (severity ≥ 7) and Security Hub (CRITICAL/HIGH) findings into the existing <code>ops_alerts</code> SNS topic</li>
+        <li>✅ <strong>EBS snapshot automation</strong> — DLM policy, weekly snapshots of <code>nextcloud-data</code> (Sundays 03:00 UTC), 4 retained</li>
+        <li>✅ <strong>S3 lifecycle rule</strong> — primary Nextcloud bucket: noncurrent versions → Standard-IA at 30 days, expire at 365, abort incomplete multipart uploads at 7</li>
+        <li>✅ <strong>Budget alarm</strong> — monthly cost budget, alerts at 80%/100% actual and 100% forecasted</li>
+        <li>✅ <strong>nginx rate limiting</strong> — applied manually over SSH; not yet folded into <code>packer/setup.sh</code>, so it won't survive an AMI rebuild until it is</li>
+        <li>✅ <strong>CloudWatch log shipping</strong> — nginx access/error logs and the Nextcloud app log now flow to CloudWatch Logs (30-day retention)</li>
+      </ul>
+      <div class="open-item" style="border-left-color: var(--accent); background: rgba(94,201,168,0.08); color: var(--accent);"><strong style="color:#8fe0c4;">Note:</strong> the CloudWatch agent's real config file is <code>/opt/aws/amazon-cloudwatch-agent/etc/config.json</code>, not <code>amazon-cloudwatch-agent.json</code> as commonly assumed — see Known Issues.</div>
     </div>
   </section>
 
@@ -565,10 +592,19 @@ terraform apply + Packer rebuild — run manually/locally</div>
     <div class="phase-card">
       <div class="phase-head">
         <div class="phase-title">S3 primary objectstore vs. human-readable paths</div>
-        <span class="badge badge-done">Resolved (plan)</span>
+        <span class="badge badge-done">Resolved</span>
       </div>
       <p class="arch-note"><strong style="color:var(--text);">Issue:</strong> assumed migration files could be uploaded directly into the primary Nextcloud S3 bucket. Doesn't work — primary objectstore uses internal keys (<code>urn:oid:xxxx</code>), not real paths, so direct writes are invisible to Nextcloud.</p>
-      <p class="arch-note"><strong style="color:var(--text);">Fix:</strong> use a separate dedicated migration S3 bucket, mount as <strong>External Storage</strong>, then run <code>occ files:scan --all</code> to index. Plan confirmed, migration not yet executed.</p>
+      <p class="arch-note"><strong style="color:var(--text);">Fix:</strong> used a separate dedicated migration S3 bucket, mounted as <strong>External Storage</strong>, indexed with <code>occ files:scan --all</code>. Migration executed and complete.</p>
+    </div>
+
+    <div class="phase-card">
+      <div class="phase-head">
+        <div class="phase-title">CloudWatch agent config file path assumption</div>
+        <span class="badge badge-done">Resolved</span>
+      </div>
+      <p class="arch-note"><strong style="color:var(--text);">Issue:</strong> assumed the agent's editable config lived at <code>/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json</code> — that path doesn't exist on this instance.</p>
+      <p class="arch-note"><strong style="color:var(--text);">Fix:</strong> the real file-sourced config is <code>/opt/aws/amazon-cloudwatch-agent/etc/config.json</code> (mirrored to <code>amazon-cloudwatch-agent.d/file_config.json</code>, translated to <code>.toml</code> at runtime). Confirmed via <code>ls</code> on the instance and cross-checked against live <code>CWAgent</code>-namespace metrics already flowing. No SSM parameter involved — plain local file, edited directly and re-applied via <code>amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:...</code>.</p>
     </div>
 
     <div class="phase-card">
@@ -656,6 +692,22 @@ terraform apply + Packer rebuild — run manually/locally</div>
       <li class="log-item">
         <div class="log-tag">GROUPS REMAINING</div>
         <div class="log-body">Phase 7's <code>groupfolders</code> app, group creation, and folder permission assignment are <strong>not yet automated or done</strong>.</div>
+      </li>
+      <li class="log-item">
+        <div class="log-tag">CLOUDWATCH AGENT</div>
+        <div class="log-body"><strong>Resolved</strong> — agent installed/configured/started, memory/disk alarms now have a real data source.</div>
+      </li>
+      <li class="log-item">
+        <div class="log-tag">DROPBOX MIGRATION</div>
+        <div class="log-body"><strong>Resolved</strong> — rclone copy, External Storage mount, and <code>occ files:scan</code> indexing all completed.</div>
+      </li>
+      <li class="log-item">
+        <div class="log-tag">ONBOARDING DOCS</div>
+        <div class="log-body"><strong>Resolved</strong> — Nextcloud URL, sync client download links, and account handoff instructions delivered to the group.</div>
+      </li>
+      <li class="log-item">
+        <div class="log-tag">RATE LIMITING → AMI</div>
+        <div class="log-body">nginx rate limiting applied manually over SSH, not yet folded into <code>packer/setup.sh</code> — won't survive an AMI rebuild until it is.</div>
       </li>
     </ul>
   </section>

--- a/onevoice-storage/terraform/backup.tf
+++ b/onevoice-storage/terraform/backup.tf
@@ -1,0 +1,61 @@
+resource "aws_iam_role" "dlm_lifecycle_role" {
+  name = "${var.organization}-${var.environment}-dlm-lifecycle-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "dlm.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${var.organization}-${var.environment}-dlm-lifecycle-role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "dlm_lifecycle_role" {
+  role       = aws_iam_role.dlm_lifecycle_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole"
+}
+
+resource "aws_dlm_lifecycle_policy" "nextcloud_data_snapshots" {
+  description        = "Weekly snapshots of the Nextcloud EBS data volume"
+  execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    target_tags = {
+      Name = aws_ebs_volume.nextcloud-data.tags["Name"]
+    }
+
+    schedule {
+      name = "weekly-snapshots"
+
+      create_rule {
+        cron_expression = "cron(0 3 ? * 1 *)" 
+      }
+
+      retain_rule {
+        count = 4 
+      }
+
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+      }
+
+      copy_tags = true
+    }
+  }
+
+  tags = {
+    Name = "${var.organization}-${var.environment}-nextcloud-data-snapshot-policy"
+  }
+}

--- a/onevoice-storage/terraform/cost.tf
+++ b/onevoice-storage/terraform/cost.tf
@@ -1,0 +1,31 @@
+resource "aws_budgets_budget" "monthly_cost" {
+  name         = "${var.organization}-${var.environment}-monthly-budget"
+  budget_type  = "COST"
+  limit_amount = var.monthly_budget_limit
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = var.ops_alert_emails
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = var.ops_alert_emails
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = var.ops_alert_emails
+  }
+}

--- a/onevoice-storage/terraform/s3.tf
+++ b/onevoice-storage/terraform/s3.tf
@@ -17,6 +17,31 @@ resource "aws_s3_bucket_versioning" "nextcloud-store-versioning" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "nextcloud-store" {
+  bucket = aws_s3_bucket.nextcloud-store.id
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+    filter {}
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 365
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.nextcloud-store-versioning]
+}
+
 resource "aws_s3_object" "onevoice_logo" {
   bucket = aws_s3_bucket.nextcloud-store.bucket
   key    = "branding/logo.png"

--- a/onevoice-storage/terraform/security.tf
+++ b/onevoice-storage/terraform/security.tf
@@ -1,0 +1,160 @@
+resource "aws_s3_bucket" "cloudtrail_logs" {
+  bucket = "${var.organization}-${var.environment}-cloudtrail-logs"
+
+  tags = {
+    Name = "${var.organization}-${var.environment}-cloudtrail-logs"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudtrail_logs" {
+  bucket                  = aws_s3_bucket.cloudtrail_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+locals {
+  cloudtrail_name = "${var.organization}-${var.environment}-trail"
+  cloudtrail_arn  = "arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${local.cloudtrail_name}"
+}
+
+# Standard CloudTrail bucket policy, scoped to this specific trail via aws:SourceArn
+# so no other trail (in this or another account) can write here.
+resource "aws_s3_bucket_policy" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AWSCloudTrailAclCheck"
+        Effect    = "Allow"
+        Principal = { Service = "cloudtrail.amazonaws.com" }
+        Action    = "s3:GetBucketAcl"
+        Resource  = aws_s3_bucket.cloudtrail_logs.arn
+        Condition = {
+          StringEquals = { "aws:SourceArn" = local.cloudtrail_arn }
+        }
+      },
+      {
+        Sid       = "AWSCloudTrailWrite"
+        Effect    = "Allow"
+        Principal = { Service = "cloudtrail.amazonaws.com" }
+        Action    = "s3:PutObject"
+        Resource  = "${aws_s3_bucket.cloudtrail_logs.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl"  = "bucket-owner-full-control"
+            "aws:SourceArn" = local.cloudtrail_arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudtrail" "main" {
+  name                          = local.cloudtrail_name
+  s3_bucket_name                = aws_s3_bucket.cloudtrail_logs.id
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  enable_log_file_validation    = true
+
+  depends_on = [aws_s3_bucket_policy.cloudtrail_logs]
+
+  tags = {
+    Name = local.cloudtrail_name
+  }
+}
+
+# --- GuardDuty ---
+
+resource "aws_guardduty_detector" "main" {
+  enable                       = true
+  finding_publishing_frequency = "FIFTEEN_MINUTES" # fast enough to be worth paging on, since findings feed SNS below
+
+  tags = {
+    Name = "${var.organization}-${var.environment}-guardduty"
+  }
+}
+
+# --- Security Hub ---
+# enable_default_standards defaults to true, auto-subscribing to AWS Foundational
+# Security Best Practices. Security Hub also auto-ingests GuardDuty findings once
+# both services are on in the same account — no extra wiring needed for that part.
+resource "aws_securityhub_account" "main" {}
+
+# --- Route high-severity findings to the existing ops-alerts SNS topic ---
+
+resource "aws_sns_topic_policy" "ops_alerts_eventbridge" {
+  arn = aws_sns_topic.ops_alerts.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowEventBridgePublish"
+        Effect    = "Allow"
+        Principal = { Service = "events.amazonaws.com" }
+        Action    = "SNS:Publish"
+        Resource  = aws_sns_topic.ops_alerts.arn
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_high_findings" {
+  name = "${var.organization}-${var.environment}-guardduty-high-findings"
+
+  event_pattern = jsonencode({
+    source      = ["aws.guardduty"]
+    detail-type = ["GuardDuty Finding"]
+    detail = {
+      severity = [{ numeric = [">=", 7] }]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_high_findings_sns" {
+  rule = aws_cloudwatch_event_rule.guardduty_high_findings.name
+  arn  = aws_sns_topic.ops_alerts.arn
+}
+
+resource "aws_cloudwatch_event_rule" "securityhub_critical_findings" {
+  name = "${var.organization}-${var.environment}-securityhub-critical-findings"
+
+  event_pattern = jsonencode({
+    source      = ["aws.securityhub"]
+    detail-type = ["Security Hub Findings - Imported"]
+    detail = {
+      findings = {
+        Severity = { Label = ["CRITICAL", "HIGH"] }
+        Workflow = { Status = ["NEW"] }
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "securityhub_critical_findings_sns" {
+  rule = aws_cloudwatch_event_rule.securityhub_critical_findings.name
+  arn  = aws_sns_topic.ops_alerts.arn
+}

--- a/onevoice-storage/terraform/vars.tf
+++ b/onevoice-storage/terraform/vars.tf
@@ -54,3 +54,9 @@ variable "ops_alert_emails" {
     "somorijoseph@gmail.com"
   ]
 }
+
+variable "monthly_budget_limit" {
+  description = "Monthly AWS cost budget threshold, in USD"
+  type        = string
+  default     = "35"
+}


### PR DESCRIPTION
[Add CloudTrail, GuardDuty, Security Hub, EBS snapshot automation, S3 lifecycle rules, and a monthly budget alarm
](https://github.com/eayanwale/onevoice-storage/commit/5bda762cdc67f07eb06503e39431fc4faf535332) 
- security.tf: multi-region CloudTrail with a dedicated encrypted/non-public
  log bucket, GuardDuty detector (15-min finding frequency), Security Hub
  with default standards, and EventBridge rules routing high-severity
  GuardDuty/Security Hub findings into the existing ops_alerts SNS topic
- backup.tf: DLM policy for weekly EBS snapshots of the Nextcloud data
  volume (Sundays 03:00 UTC via cron_expression, 4 retained) plus its
  service role; the prior one-off aws_ebs_snapshot in compute.tf is left
  in place rather than removed
- s3.tf: lifecycle rule on the primary Nextcloud bucket transitioning
  noncurrent versions to Standard-IA at 30 days and expiring them at 365
- cost.tf + vars.tf: monthly cost budget (var.monthly_budget_limit,
  default $35) alerting at 80%/100% actual and 100% forecasted to the
  existing ops alert emails