### PR TITLE
Infra/44 bake config drift

### DIFF
--- a/docs/config-drift-implementation-plan.md
+++ b/docs/config-drift-implementation-plan.md
@@ -1,0 +1,74 @@
+# Config-drift implementation plan
+
+Tracking doc for closing #41–#44 (fold cloudflared, nginx rate limiting, and the MCP server/maintenance timer back into `packer/setup.sh`). The actual implementation now lives in the real files — this doc is status/tracking only, not a code copy, to avoid the doc and the real files drifting out of sync with each other (which already happened once: two real bugs got fixed directly in the files and weren't worth mirroring back here).
+
+Branch: `infra/44-bake-config-drift` off `dev` (not yet pushed).
+
+## Files touched
+
+New, under `onevoice-storage/packer/files/`: `rate-limit.conf`, `cloudflared.service`, `nextcloud-mcp.service`, `nextcloud-maintenance.service`, `nextcloud-maintenance.timer`, `nextcloud-maintenance-check.sh`.
+
+Edited: `onevoice-storage/packer/nextcloud.pkr.hcl`, `onevoice-storage/packer/setup.sh`, `onevoice-storage/terraform/scripts/user-data.sh`, `onevoice-storage/terraform/compute.tf`, `onevoice-storage/terraform/data.tf`.
+
+## Verification status
+
+| Item | Status |
+|---|---|
+| nginx rate limiting (`rate-limit.conf`, `limit_req` line) | Implemented, not yet diffed against the live instance's actual `/etc/nginx/conf.d/rate-limit.conf` |
+| `cloudflared.service` | Implemented with `Type=notify` + `TimeoutStartSec=15` (more accurate than an earlier `Type=simple` draft — cloudflared genuinely supports systemd readiness notification). Not yet diffed against `systemctl cat cloudflared` on the live box. |
+| `nextcloud-mcp.service`, `nextcloud-maintenance.service`, `nextcloud-maintenance.timer` | Implemented, matches what's documented in `nextcloud-maintenance-automation.md` |
+| `nextcloud-maintenance-check.sh` | Implemented as an independent rewrite (not a copy of the live script — SSH access to pull the exact original wasn't available). Includes two fixes an earlier draft was missing: a `trap cleanup EXIT` so the temp workdir is always removed even on failure, and `git config user.name`/`user.email` before committing (a fresh instance has no global git identity, so this was a real gap before) |
+| MCP server install method | Confirmed via `ls -la` on the live instance: full `git clone` of the upstream repo (github.com/cbcoutinho/nextcloud-mcp-server) + `uv sync`, not a standalone `uv`-managed dependency project. Still open: whether the clone should pin to a specific tag/commit rather than always cloning `HEAD` — check `git log -1 --oneline` in that directory on the live box. |
+| `.env` shape | Confirmed against the live `.env`: single-user BasicAuth mode, no OAuth — just `NEXTCLOUD_HOST`, `NEXTCLOUD_USERNAME`, `NEXTCLOUD_PASSWORD`. No `TOKEN_STORAGE_DB`/`TOKEN_ENCRYPTION_KEY`, so only 2 SSM params needed for the MCP server (not 3) |
+| `setup.sh` cloudflared install | Fixed: `curl -fsSl` → `-fsSL` (was silently dropping `-L`/follow-redirects due to a lowercase-`l` typo) and `yum install cloudflared` → `yum install -y cloudflared` (was missing `-y`, which would've hung the non-interactive Packer build) |
+| `data.tf` IAM policy | Fixed: dropped a leftover `nextcloud-mcp/token-encryption-key` ARN that had no corresponding SSM param once single-user mode was confirmed |
+| Terraform workspace support (`data.tf`'s `terraform_remote_state.bootstrap`) | Implemented — reads whichever workspace the main stack is currently in, so it works correctly for both prod (default workspace) and the sandbox test environment |
+
+## Testing in sandbox first
+
+Before merging to `dev`/pushing to prod, this is being validated in an isolated `sandbox` environment (same AWS account, separate `environment` namespace, isolated via Terraform workspaces — not a separate AWS account). See the workspace/state-isolation discussion in this conversation for the full reasoning; short version:
+
+1. `infra/bootstrap`: `terraform workspace new sandbox` → `terraform apply -var="environment=sandbox"` (fresh DB/admin passwords at `/onevoice/sandbox/...`, isolated from prod's state)
+2. `onevoice-storage/terraform`: `terraform workspace new sandbox`
+3. Build a fresh AMI with the config-drift changes:
+   ```
+   cd onevoice-storage/packer
+   packer init nextcloud.pkr.hcl
+   packer validate nextcloud.pkr.hcl
+   packer build nextcloud.pkr.hcl
+   ```
+   Note: `ami_name` includes `{{timestamp}}`, and `data.aws_ami.nextcloud` always picks the most recent `ami-nextcloud-*` AMI regardless of environment — so this new AMI becomes what prod would use on its next apply too, not just sandbox.
+4. Create a **separate** Cloudflare Tunnel + hostname for sandbox (don't reuse prod's — same hostname would make it impossible to tell which backend answered). Local service targets are the same as prod either way: `localhost:80` (nginx) and `localhost:8000` (MCP server).
+5. Create sandbox's 4 SSM params (see below), then `terraform apply -var="environment=sandbox"` in the main stack.
+
+## SSM parameters needed (per environment)
+
+Not managed by Terraform — these come from external systems, so Terraform only grants read access (`data.tf`). Create manually before first boot in each environment:
+```
+aws ssm put-parameter --profile onevoice --type SecureString --name "/onevoice/<env>/cloudflared/tunnel-token" --value "<from that environment's Cloudflare Tunnel>"
+aws ssm put-parameter --profile onevoice --type SecureString --name "/onevoice/<env>/nextcloud-mcp/username" --value "<NEXTCLOUD_USERNAME>"
+aws ssm put-parameter --profile onevoice --type SecureString --name "/onevoice/<env>/nextcloud-mcp/app-password" --value "<NEXTCLOUD_PASSWORD>"
+aws ssm put-parameter --profile onevoice --type SecureString --name "/onevoice/<env>/maintenance/github-pat" --value "<fine-grained PAT>"
+```
+For prod specifically, get the MCP username/app-password by reading them straight off the live `.env` (`cat ~/nextcloud-mcp-server/.env` over SSH) rather than generating new ones. For sandbox, generate fresh values (new app password created via the sandbox Nextcloud instance's own admin UI once it's up, new tunnel token from its own Cloudflare Tunnel).
+
+## Once sandbox validates
+
+```
+git add onevoice-storage/packer/files/ onevoice-storage/packer/nextcloud.pkr.hcl onevoice-storage/packer/setup.sh onevoice-storage/terraform/compute.tf onevoice-storage/terraform/data.tf onevoice-storage/terraform/scripts/user-data.sh
+git commit -m "Bake Cloudflare Tunnel, nginx rate limiting, and MCP/maintenance automation into the golden AMI
+
+Closes #41, #42, #43."
+git push -u origin infra/44-bake-config-drift
+```
+Open the PR: base `dev`, title `infra(config-drift): bake cloudflared, nginx rate limiting, and MCP/maintenance automation into the golden AMI (#44)`, body includes `Closes #41`, `Closes #42`, `Closes #43`.
+
+## Still outstanding
+
+`terraform validate` passes (confirmed). `packer validate`/`packer build` haven't been run yet. Also still worth pulling from the live prod instance to fully close out the Verification status table above:
+```bash
+cat /etc/nginx/conf.d/rate-limit.conf
+cat /etc/nginx/conf.d/nextcloud.conf
+systemctl cat cloudflared
+cd /home/ec2-user/nextcloud-mcp-server && git log -1 --oneline
+```

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -1,0 +1,85 @@
+# Deployment runbook
+
+Step-by-step for standing up (or rebuilding) the `sandbox` or `prod` environment. Living doc — add to it as new steps/gotchas turn up.
+
+## Prerequisites
+
+- Terraform >= 1.7.0, Packer, AWS CLI
+- `--profile onevoice` configured with credentials for the target AWS account
+- Repo root: `d:\Enoch\workspace\personal\onevoice`
+
+## 1. Bootstrap (once per environment)
+
+```
+cd infra\bootstrap
+terraform workspace new <env>      # e.g. sandbox — skip for prod, it's already on the default workspace
+terraform apply -var="environment=<env>"
+```
+Creates fresh `random_password`-generated DB/admin passwords in SSM at `/onevoice/<env>/nextcloud/{db-password,admin-password}`. Also creates an unused `onevoice-<env>-terraform-state` S3 bucket as a side effect (nothing actually uses it as a backend — safe to ignore).
+
+## 2. Build the AMI
+
+```
+cd onevoice-storage\packer
+packer init nextcloud.pkr.hcl
+packer validate nextcloud.pkr.hcl
+packer build nextcloud.pkr.hcl
+```
+One AMI serves all environments — `data.aws_ami.nextcloud` always picks the most recent `ami-nextcloud-*`, so a build here affects the *next* apply for every environment, not just the one you're working on.
+
+## 3. Cloudflare Tunnel (once per environment)
+
+Cloudflare Zero Trust dashboard → Networks → Tunnels → **Create a tunnel** (a new one per environment — never reuse another environment's tunnel/hostname).
+
+Two public hostname routes on that tunnel:
+
+| Hostname | Service | Notes |
+|---|---|---|
+| `<env>.knoch.dev` (prod uses bare `onevoice.knoch.dev`) | `HTTP`, `127.0.0.1:80` | nginx/Nextcloud |
+| `mcp-<env>.knoch.dev` | `HTTP`, `127.0.0.1:8000` | MCP server — **use `127.0.0.1` explicitly, not `localhost`**. The MCP server only binds `127.0.0.1`; `localhost` can resolve to `::1` first and silently fail to connect. |
+
+Copy the tunnel token — needed in step 4.
+
+## 4. Create required SSM parameters (per environment)
+
+Terraform grants read access to these but does not create them — they come from external systems Terraform has no way to generate.
+
+```
+aws ssm put-parameter --profile onevoice --type SecureString --region us-east-1 --name "/onevoice/<env>/cloudflared/tunnel-token" --value "<from step 3>"
+aws ssm put-parameter --profile onevoice --type SecureString --region us-east-1 --name "/onevoice/<env>/nextcloud-mcp/username" --value "<nextcloud username for the MCP app password>"
+aws ssm put-parameter --profile onevoice --type SecureString --region us-east-1 --name "/onevoice/<env>/nextcloud-mcp/app-password" --value "<generated in Nextcloud Settings > Security > Create new app password>"
+aws ssm put-parameter --profile onevoice --type SecureString --region us-east-1 --name "/onevoice/<env>/maintenance/github-pat" --value "<fine-grained PAT, Contents/Issues/PRs write, scoped to this repo>"
+```
+
+For prod specifically, the MCP username/app-password can be read straight off the live `.env` (`cat ~/nextcloud-mcp-server/.env` over SSH) instead of generating new ones.
+
+The migration bucket's access key is **not** on this list — Terraform generates and writes that one itself (`iam.tf` → SSM), nothing to do manually.
+
+## 5. Deploy the main stack
+
+```
+cd onevoice-storage\terraform
+terraform workspace new <env>      # skip for prod (default workspace)
+terraform plan -var="environment=<env>"
+```
+Check the plan touches only `onevoice-<env>-*` resources — **stop and investigate if anything named `onevoice-prod-*` shows up** while working in a non-prod workspace.
+
+```
+terraform apply -var="environment=<env>"
+```
+
+## 6. Verify
+
+```bash
+curl -i https://<env>.knoch.dev/status.php          # expect real JSON, {"installed":true,...}
+curl -i https://mcp-<env>.knoch.dev/mcp -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl-test","version":"1.0"}}}'
+```
+Log in via the web UI (in a private/incognito window — see caution below) and confirm Settings → Administration → External Storage shows the "Migration" mount.
+
+## Cautions
+
+- **Recreating the instance alone (`terraform apply -replace="aws_instance.nextcloud-server"`) is not equivalent to a clean install.** RDS isn't touched by `-replace`, so a fresh instance's `occ maintenance:install` collides with the already-installed database ("The Login is already being used") and `set -e` kills the rest of first-boot provisioning right there. For a genuinely clean end-to-end test, destroy and re-apply the **whole** stack, not just the instance.
+- **`terraform destroy` will likely fail on `nextcloud-store`** (primary S3 bucket) if it has real objects and hasn't been emptied — safe to ignore and re-run `apply` afterward; Terraform recreates everything else and leaves the still-existing bucket alone. Note the old bucket contents become orphaned (invisible to a fresh install's empty database) rather than actually cleaned up.
+- **Fresh instance + old browser session = "HMAC does not match" log spam.** Harmless — the browser has a session cookie encrypted under the previous instance's now-gone secret. Clear cookies or use a private window.
+- **Before applying any of this to prod**, add `lifecycle { prevent_destroy = true }` and `force_destroy = false` to `aws_s3_bucket.onevoice_migration` in `s3.tf` — deliberately not added yet since it would block sandbox's destroy/apply test cycles. Migration bucket data must never be destroyable once this matters for real.
+- **Trashbin is disabled instance-wide** (`files_trashbin` app) — S3-backed storage deletes crash its move-to-trash step (#28). No undo/trash anywhere on the instance as a result.

--- a/onevoice-storage/packer/files/cloudflared.service
+++ b/onevoice-storage/packer/files/cloudflared.service
@@ -1,0 +1,15 @@
+# /etc/systemd/system/cloudflared.service
+[Unit]
+Description=Cloudflare Tunnel client
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+TimeoutStartSec=15
+Type=notify
+ExecStart=/usr/bin/cloudflared --no-autoupdate tunnel run --token-file /etc/cloudflared/token
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/onevoice-storage/packer/files/nextcloud-maintenance-check.sh
+++ b/onevoice-storage/packer/files/nextcloud-maintenance-check.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+set -uo pipefail
+
+NC_PATH="/var/www/nextcloud"
+REPO="eayanwale/onevoice-storage"
+REPO_URL="https://github.com/${REPO}.git"
+SNS_TOPIC_ARN="arn:aws:sns:us-east-1:622247620719:onevoice-prod-ops-alerts"
+SNS_REGION="us-east-1"
+LABEL="maintenance"
+DATE=$(date -u +%Y-%m-%d)
+MONTH_YEAR=$(date -u +"%B %Y")
+
+TEST_MODE=0
+if [ "${1:-}" = "--test" ]; then
+  TEST_MODE=1
+fi
+
+if [ "$TEST_MODE" = "1" ]; then
+  BRANCH="maintenance/test-${DATE}-$(date -u +%H%M%S)"
+  TITLE="[TEST] Nextcloud maintenance checklist - ${MONTH_YEAR}"
+  SECTION_TITLE="## ${MONTH_YEAR} Nextcloud maintenance (TEST RUN, ${DATE})"
+  SUBJECT_PREFIX="[TEST] "
+else
+  BRANCH="maintenance/${DATE}"
+  TITLE="Nextcloud maintenance checklist - ${MONTH_YEAR}"
+  SECTION_TITLE="## ${MONTH_YEAR} Nextcloud maintenance (automated check, ${DATE})"
+  SUBJECT_PREFIX=""
+fi
+
+WORKDIR=$(mktemp -d)
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+notify() {
+  local subject="$1"
+  local message="$2"
+  aws sns publish --region "$SNS_REGION" --topic-arn "$SNS_TOPIC_ARN" \
+    --subject "${SUBJECT_PREFIX}${subject}" --message "$message" >/dev/null
+}
+
+fail() {
+  local step="$1"
+  echo "FAILED: $step"
+  notify "Nextcloud maintenance automation FAILED" "Step failed: ${step}. Host $(hostname), $(date -u +%Y-%m-%dT%H:%M:%SZ). Check the box directly - no PR was opened this run."
+  exit 1
+}
+
+echo "==> Gathering findings"
+
+CORE_VERSION=$(sudo -u nginx php "$NC_PATH/occ" status 2>&1 | grep -oP 'versionstring: \K.*' || echo "unknown")
+UPDATE_CHECK=$(sudo -u nginx php "$NC_PATH/occ" update:check 2>&1)
+
+DISK=$(df -h / | tail -1)
+DISK_PCT=$(echo "$DISK" | awk '{print $5}')
+DISK_AVAIL=$(echo "$DISK" | awk '{print $4}')
+
+MEM_LINE=$(free -h | awk '/^Mem:/')
+MEM_AVAIL=$(echo "$MEM_LINE" | awk '{print $7}')
+MEM_TOTAL=$(echo "$MEM_LINE" | awk '{print $2}')
+
+DNF_UPDATES=$(sudo dnf check-update 2>&1 | grep -E '^\S+\.(x86_64|noarch)' | wc -l || echo "0")
+
+RUNNING_KERNEL=$(uname -r)
+LATEST_INSTALLED_KERNEL=$(rpm -q kernel | sed 's/^kernel-//' | sort -V | tail -1)
+if [ "$RUNNING_KERNEL" = "$LATEST_INSTALLED_KERNEL" ]; then
+  REBOOT_LINE="No reboot needed (running kernel matches latest installed: ${RUNNING_KERNEL})"
+else
+  REBOOT_LINE="Reboot recommended: running ${RUNNING_KERNEL}, latest installed is ${LATEST_INSTALLED_KERNEL}"
+fi
+
+CRON_USER=$(crontab -l 2>&1)
+CRON_ROOT=$(sudo crontab -l 2>&1)
+if echo "$CRON_USER $CRON_ROOT" | grep -qi 'no crontab'; then
+  BACKUP_CRON_LINE="No cron-based backup job found (user or root crontab)"
+else
+  BACKUP_CRON_LINE="Cron entries present - review manually: user=[$CRON_USER] root=[$CRON_ROOT]"
+fi
+
+EXITED_CONTAINERS=$(sudo docker ps -a --filter "status=exited" --format '{{.Names}} ({{.Image}})' 2>&1)
+
+echo "==> Building checklist section"
+
+cat > "$WORKDIR/section.md" <<EOF
+${SECTION_TITLE}
+
+- [ ] Verify EC2 public IP is still current (dynamic, not elastic) - check via \`aws ec2 describe-instances --profile onevoice\`
+- [ ] Update Nextcloud core: currently ${CORE_VERSION}. ${UPDATE_CHECK}
+- [ ] Check Nextcloud app updates in Admin > Apps > Updates (not reliably listable via occ CLI)
+- [ ] OS packages: ${DNF_UPDATES} package(s) with updates available per \`dnf check-update\`
+- [ ] Kernel/reboot: ${REBOOT_LINE}
+- [ ] Disk usage: ${DISK_PCT} used, ${DISK_AVAIL} available on /
+- [ ] Memory: ${MEM_AVAIL} available of ${MEM_TOTAL}
+- [ ] Backups: ${BACKUP_CRON_LINE}
+$(if [ -n "$EXITED_CONTAINERS" ]; then echo "- [ ] Investigate exited Docker container(s): ${EXITED_CONTAINERS}"; fi)
+
+_Generated automatically by nextcloud-maintenance-check.sh on $(hostname) at $(date -u +%Y-%m-%dT%H:%M:%SZ)._
+EOF
+
+echo "==> Ensuring label exists"
+gh label list --repo "$REPO" --json name --jq '.[].name' | grep -qx "$LABEL" || \
+  gh label create "$LABEL" --repo "$REPO" --color 0E8A16 --description "Nextcloud server maintenance checklist"
+
+echo "==> Creating tracking issue"
+ISSUE_URL=$(gh issue create \
+  --repo "$REPO" \
+  --title "$TITLE" \
+  --body "$(cat "$WORKDIR/section.md")" \
+  --label "$LABEL") || fail "gh issue create"
+ISSUE_NUM=$(basename "$ISSUE_URL")
+echo "==> Issue: $ISSUE_URL"
+
+echo "==> Cloning repo"
+git clone --quiet --depth 1 -b dev "$REPO_URL" "$WORKDIR/repo" || fail "git clone"
+cd "$WORKDIR/repo"
+git checkout -b "$BRANCH"
+
+mkdir -p systems
+touch systems/maintenance.md
+{ echo; cat "$WORKDIR/section.md"; } >> systems/maintenance.md
+
+git config user.name "Nextcloud Maintenance Bot"
+git config user.email "maintenance-bot@onevoice.local"
+git add systems/maintenance.md
+git commit --quiet -m "Add ${MONTH_YEAR} Nextcloud maintenance checklist (automated)"
+
+echo "==> Pushing branch"
+git push --quiet origin "$BRANCH" || fail "git push"
+
+echo "==> Opening PR"
+PR_URL=$(gh pr create \
+  --repo "$REPO" \
+  --base dev \
+  --head "$BRANCH" \
+  --title "$TITLE" \
+  --body "Closes #${ISSUE_NUM}
+
+Automated monthly Nextcloud maintenance check. Review findings below and complete the checklist in \`systems/maintenance.md\` as maintenance is performed." \
+  --assignee eayanwale \
+  --label "$LABEL") || fail "gh pr create"
+
+echo "==> Notifying via SNS"
+notify "Nextcloud maintenance checklist ready" "${TITLE} is ready: PR ${PR_URL} (tracking issue ${ISSUE_URL})"
+
+echo "==> Done: ${PR_URL}"

--- a/onevoice-storage/packer/files/nextcloud-maintenance.service
+++ b/onevoice-storage/packer/files/nextcloud-maintenance.service
@@ -1,0 +1,12 @@
+# /etc/systemd/system/nextcloud-maintenance.service
+[Unit]
+Description=Nextcloud monthly maintenance check and PR
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=ec2-user
+ExecStart=/home/ec2-user/scripts/nextcloud-maintenance-check.sh
+StandardOutput=journal
+StandardError=journal

--- a/onevoice-storage/packer/files/nextcloud-maintenance.timer
+++ b/onevoice-storage/packer/files/nextcloud-maintenance.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run Nextcloud maintenance check monthly on the 15th
+
+[Timer]
+OnCalendar=*-*-15 13:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/onevoice-storage/packer/files/nextcloud-mcp.service
+++ b/onevoice-storage/packer/files/nextcloud-mcp.service
@@ -1,0 +1,16 @@
+# /etc/systemd/system/nextcloud-mcp.service
+[Unit]
+Description=Nextcloud MCP Server
+After=network.target
+
+[Service]
+Type=simple
+User=ec2-user
+WorkingDirectory=/home/ec2-user/nextcloud-mcp-server
+EnvironmentFile=/home/ec2-user/nextcloud-mcp-server/.env
+ExecStart=/home/ec2-user/.local/bin/uv run nextcloud-mcp-server run --log-level info
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/onevoice-storage/packer/files/rate-limit.conf
+++ b/onevoice-storage/packer/files/rate-limit.conf
@@ -1,0 +1,1 @@
+limit_req_zone $binary_remote_addr zone=nextcloud_limit:10m rate=10r/s;

--- a/onevoice-storage/packer/nextcloud.pkr.hcl
+++ b/onevoice-storage/packer/nextcloud.pkr.hcl
@@ -73,6 +73,18 @@ source "amazon-ebs" "amazon_ebs" {
 
 build {
   sources = ["source.amazon-ebs.amazon_ebs"]
+
+  # Packer's file provisioner can create /tmp/packer-files as a plain file
+  # instead of a directory when uploading multiple files — pre-create it.
+  provisioner "shell" {
+    inline = ["mkdir -p /tmp/packer-files"]
+  }
+
+  provisioner "file" {
+    source      = "files/"
+    destination = "/tmp/packer-files"
+  }
+
   provisioner "shell" {
     script          = "setup.sh"
     execute_command = "sudo -E bash '{{ .Path }}'"

--- a/onevoice-storage/packer/setup.sh
+++ b/onevoice-storage/packer/setup.sh
@@ -10,31 +10,27 @@ dnf install -y \
   php8.2-zip php8.2-intl php8.2-mysqlnd php8.2-bcmath \
   php8.2-gmp php8.2-opcache
 
-# --- Nextcloud download ---
-NEXTCLOUD_VERSION="30.0.0"  # pin a version, bump deliberately later
+NEXTCLOUD_VERSION="30.0.0" # bump deliberately, not automatically
 cd /tmp
 curl -O "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.zip"
 unzip -q "nextcloud-${NEXTCLOUD_VERSION}.zip" -d /var/www/
 rm -f "nextcloud-${NEXTCLOUD_VERSION}.zip"
 
-# --- Ownership/permissions (nginx runs as 'nginx' on AL2023) ---
 chown -R nginx:nginx /var/www/nextcloud
 find /var/www/nextcloud/ -type d -exec chmod 750 {} \;
 find /var/www/nextcloud/ -type f -exec chmod 640 {} \;
 
-# --- php-fpm pool tweak: run as nginx user ---
 sed -i 's/^user = .*/user = nginx/' /etc/php-fpm.d/www.conf
 sed -i 's/^group = .*/group = nginx/' /etc/php-fpm.d/www.conf
 sed -i 's/^listen.owner = .*/listen.owner = nginx/' /etc/php-fpm.d/www.conf
 sed -i 's/^listen.group = .*/listen.group = nginx/' /etc/php-fpm.d/www.conf
 
-# --- PHP session directory: must be writable by the nginx user, since php-fpm
-# now runs as nginx (not the default apache/root owner from the base package) ---
 mkdir -p /var/lib/php/session
 chown -R nginx:nginx /var/lib/php/session
 chmod 700 /var/lib/php/session
 
-# --- nginx server block for Nextcloud ---
+cp /tmp/packer-files/rate-limit.conf /etc/nginx/conf.d/rate-limit.conf
+
 cat > /etc/nginx/conf.d/nextcloud.conf <<'EOF'
 server {
     listen 80;
@@ -45,6 +41,7 @@ server {
     fastcgi_buffers 64 4K;
 
     location / {
+        limit_req zone=nextcloud_limit burst=20 nodelay;
         rewrite ^ /index.php$request_uri;
     }
 
@@ -59,22 +56,55 @@ server {
         include fastcgi_params;
     }
 
-    location ~ \.(?:css|js|svg|gif|png|jpg|ico|woff2?)$ {
+    location ~ \.(?:css|js|mjs|svg|gif|png|jpg|ico|woff2?)$ {
         expires 30d;
         access_log off;
     }
 }
 EOF
 
-# remove default nginx conf so it doesn't conflict
 rm -f /etc/nginx/conf.d/default.conf 2>/dev/null || true
 
-# --- certbot (binary only, no cert issuance at bake time — no DNS yet) ---
+# certbot: binary only, no cert issuance at bake time — no DNS yet
 # dnf install -y python3-pip
 # pip3 install certbot certbot-nginx
 
-# --- enable services for boot (don't start here — AMI shouldn't start with live state) ---
+curl -fsSL https://pkg.cloudflare.com/cloudflared-ascii.repo | sudo tee /etc/yum.repos.d/cloudflared.repo
+sudo yum install -y cloudflared
+cp /tmp/packer-files/cloudflared.service /etc/systemd/system/cloudflared.service
+
+dnf install -y git
+
+dnf install -y 'dnf-command(config-manager)'
+dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+dnf install -y gh --repo gh-cli
+
+# github.com/cbcoutinho/nextcloud-mcp-server: full clone + uv sync, not a
+# standalone uv-managed dependency project.
+sudo -u ec2-user bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+sudo -u ec2-user bash -c '
+  git clone https://github.com/cbcoutinho/nextcloud-mcp-server.git /home/ec2-user/nextcloud-mcp-server
+  cd /home/ec2-user/nextcloud-mcp-server
+  /home/ec2-user/.local/bin/uv sync
+'
+
+mkdir -p /home/ec2-user/scripts
+chown ec2-user:ec2-user /home/ec2-user/scripts
+
+cp /tmp/packer-files/nextcloud-maintenance-check.sh /home/ec2-user/scripts/nextcloud-maintenance-check.sh
+chown ec2-user:ec2-user /home/ec2-user/scripts/nextcloud-maintenance-check.sh
+chmod 700 /home/ec2-user/scripts/nextcloud-maintenance-check.sh
+
+cp /tmp/packer-files/nextcloud-mcp.service /etc/systemd/system/nextcloud-mcp.service
+cp /tmp/packer-files/nextcloud-maintenance.service /etc/systemd/system/nextcloud-maintenance.service
+cp /tmp/packer-files/nextcloud-maintenance.timer /etc/systemd/system/nextcloud-maintenance.timer
+systemctl daemon-reload
+
 systemctl enable nginx
 systemctl enable php-fpm
+systemctl enable cloudflared
+systemctl enable nextcloud-mcp
+# nextcloud-maintenance.service is a oneshot triggered by the timer, not enabled directly
+systemctl enable nextcloud-maintenance.timer
 
 echo "Nextcloud AMI provisioning complete."

--- a/onevoice-storage/terraform/compute.tf
+++ b/onevoice-storage/terraform/compute.tf
@@ -1,5 +1,5 @@
 resource "aws_key_pair" "nextcloud-key" {
-  key_name   = "nextcloud-key"
+  key_name   = "${var.organization}-${var.environment}-nextcloud-key"
   public_key = file("${path.module}/keys/nextcloud-key.pub")
 }
 
@@ -8,7 +8,7 @@ resource "aws_instance" "nextcloud-server" {
   instance_type               = "t3.medium"
   subnet_id                   = aws_subnet.pub-a.id
   vpc_security_group_ids      = [aws_security_group.nextcloud-sg.id]
-  # associate_public_ip_address = true
+  associate_public_ip_address = true
   key_name                    = aws_key_pair.nextcloud-key.key_name
   iam_instance_profile        = aws_iam_instance_profile.nextcloud-instance-profile.name
 
@@ -25,7 +25,15 @@ resource "aws_instance" "nextcloud-server" {
       elastic_ip              = "x.x.x.x"
       organization            = var.organization
       environment             = var.environment
-      domain_name             = "" # no domain registered yet — Phase 6
+
+      domain_name                      = local.domain_name
+      cloudflare_tunnel_token_ssm_path = "/${var.organization}/${var.environment}/cloudflared/tunnel-token"
+      mcp_username_ssm_path            = "/${var.organization}/${var.environment}/nextcloud-mcp/username"
+      mcp_password_ssm_path            = "/${var.organization}/${var.environment}/nextcloud-mcp/app-password"
+      github_pat_ssm_path              = "/${var.organization}/${var.environment}/maintenance/github-pat"
+      migration_bucket                 = aws_s3_bucket.onevoice_migration.bucket
+      migration_access_key_id_ssm_path = "/${var.organization}/${var.environment}/nextcloud/migration-bucket/access-key-id"
+      migration_secret_key_ssm_path    = "/${var.organization}/${var.environment}/nextcloud/migration-bucket/secret-access-key"
     }
   )
 

--- a/onevoice-storage/terraform/data.tf
+++ b/onevoice-storage/terraform/data.tf
@@ -4,9 +4,13 @@ data "aws_caller_identity" "current" {}
 data "terraform_remote_state" "bootstrap" {
   backend = "s3"
 
+  # Backend blocks can't reference variables, so environment isolation is
+  # via Terraform workspaces (same bucket, key auto-prefixed per workspace)
+  # rather than a var-driven bucket/key here. Requires bootstrap to have
+  # been applied under a matching workspace name.
   config = {
     bucket  = "onevoice-prod-terraform-state"
-    key     = "infra/bootstrap/terraform.tfstate"
+    key     = terraform.workspace == "default" ? "infra/bootstrap/terraform.tfstate" : "env:/${terraform.workspace}/infra/bootstrap/terraform.tfstate"
     region  = "us-east-1"
     profile = var.profile
   }
@@ -21,7 +25,15 @@ data "aws_iam_policy_document" "ec2_ssm_access" {
     ]
     resources = [
       "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.organization}/${var.environment}/nextcloud/db-password",
-      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.organization}/${var.environment}/nextcloud/admin-password"
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.organization}/${var.environment}/nextcloud/admin-password",
+      # cloudflared/nextcloud-mcp/maintenance params below are NOT managed
+      # by Terraform (created out-of-band from external systems) — read-only here.
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.organization}/${var.environment}/cloudflared/tunnel-token",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.organization}/${var.environment}/nextcloud-mcp/username",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.organization}/${var.environment}/nextcloud-mcp/app-password",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.organization}/${var.environment}/maintenance/github-pat",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.organization}/${var.environment}/nextcloud/migration-bucket/access-key-id",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.organization}/${var.environment}/nextcloud/migration-bucket/secret-access-key"
     ]
   }
 }
@@ -48,4 +60,10 @@ data "aws_ami" "nextcloud" {
 locals {
   db_password = data.aws_ssm_parameter.db_password.value
   ami_id      = data.aws_ami.nextcloud.id
+
+  # Prod keeps the bare "onevoice.knoch.dev" (that's the one already live via
+  # Cloudflare Tunnel); every other environment gets its own subdomain, e.g.
+  # sandbox -> "sandbox.knoch.dev". Each environment's Cloudflare Tunnel must
+  # be configured to route its own subdomain before this changes anything.
+  domain_name = var.environment == "prod" ? "onevoice.knoch.dev" : "${var.environment}.knoch.dev"
 }

--- a/onevoice-storage/terraform/iam.tf
+++ b/onevoice-storage/terraform/iam.tf
@@ -133,3 +133,23 @@ resource "aws_iam_user_policy" "nextcloud_migration_mount" {
 resource "aws_iam_access_key" "nextcloud_migration_mount" {
   user = aws_iam_user.nextcloud_migration_mount.name
 }
+
+resource "aws_ssm_parameter" "nextcloud_migration_access_key_id" {
+  name  = "/${var.organization}/${var.environment}/nextcloud/migration-bucket/access-key-id"
+  type  = "SecureString"
+  value = aws_iam_access_key.nextcloud_migration_mount.id
+
+  tags = {
+    Name = "${var.organization}-${var.environment}-nextcloud-migration-access-key-id"
+  }
+}
+
+resource "aws_ssm_parameter" "nextcloud_migration_secret_access_key" {
+  name  = "/${var.organization}/${var.environment}/nextcloud/migration-bucket/secret-access-key"
+  type  = "SecureString"
+  value = aws_iam_access_key.nextcloud_migration_mount.secret
+
+  tags = {
+    Name = "${var.organization}-${var.environment}-nextcloud-migration-secret-access-key"
+  }
+}

--- a/onevoice-storage/terraform/scripts/user-data.sh
+++ b/onevoice-storage/terraform/scripts/user-data.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
-# --- Wait for network/cloud-init to settle ---
 sleep 10
 
-# --- Pull DB password from SSM (same param bootstrap created) ---
 DB_PASSWORD=$(aws ssm get-parameter \
   --name "${db_password_ssm_path}" \
   --with-decryption \
@@ -12,7 +10,6 @@ DB_PASSWORD=$(aws ssm get-parameter \
   --output text \
   --region "${aws_region}")
 
-# --- Pull admin password from SSM (same param bootstrap created) ---
 ADMIN_PASSWORD=$(aws ssm get-parameter \
   --name "${admin_password_ssm_path}" \
   --with-decryption \
@@ -20,17 +17,72 @@ ADMIN_PASSWORD=$(aws ssm get-parameter \
   --output text \
   --region "${aws_region}")
 
-# --- Start services (enabled at bake time, not started) ---
+CLOUDFLARE_TUNNEL_TOKEN=$(aws ssm get-parameter \
+  --name "${cloudflare_tunnel_token_ssm_path}" \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text \
+  --region "${aws_region}")
+
+MCP_USERNAME=$(aws ssm get-parameter \
+  --name "${mcp_username_ssm_path}" \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text \
+  --region "${aws_region}")
+
+MCP_APP_PASSWORD=$(aws ssm get-parameter \
+  --name "${mcp_password_ssm_path}" \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text \
+  --region "${aws_region}")
+
+GITHUB_PAT=$(aws ssm get-parameter \
+  --name "${github_pat_ssm_path}" \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text \
+  --region "${aws_region}")
+
+MIGRATION_ACCESS_KEY_ID=$(aws ssm get-parameter \
+  --name "${migration_access_key_id_ssm_path}" \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text \
+  --region "${aws_region}")
+
+MIGRATION_SECRET_ACCESS_KEY=$(aws ssm get-parameter \
+  --name "${migration_secret_key_ssm_path}" \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text \
+  --region "${aws_region}")
+
+mkdir -p /etc/cloudflared
+echo "$${CLOUDFLARE_TUNNEL_TOKEN}" > /etc/cloudflared/token
+chmod 600 /etc/cloudflared/token
+systemctl enable --now cloudflared
+
+cat > /home/ec2-user/nextcloud-mcp-server/.env <<EOF
+NEXTCLOUD_HOST=https://${domain_name}
+NEXTCLOUD_USERNAME=$${MCP_USERNAME}
+NEXTCLOUD_PASSWORD=$${MCP_APP_PASSWORD}
+EOF
+chown ec2-user:ec2-user /home/ec2-user/nextcloud-mcp-server/.env
+chmod 600 /home/ec2-user/nextcloud-mcp-server/.env
+systemctl enable --now nextcloud-mcp
+
+sudo -u ec2-user bash -c "echo '$${GITHUB_PAT}' | gh auth login --with-token"
+sudo -u ec2-user gh auth setup-git
+systemctl enable --now nextcloud-maintenance.timer
+
 systemctl start php-fpm
 systemctl start nginx
 
-# Increase PHP memory limit to 512M
 sed -i 's/^memory_limit = .*/memory_limit = 512M/' /etc/php.ini
-
-# Restart PHP-FPM to apply
 systemctl restart php-fpm
 
-# --- Run Nextcloud CLI install (idempotent-ish: skip if already configured) ---
 if [ ! -f /var/www/nextcloud/config/config.php ]; then
   sudo -u nginx php /var/www/nextcloud/occ maintenance:install \
     --database "mysql" \
@@ -42,9 +94,8 @@ if [ ! -f /var/www/nextcloud/config/config.php ]; then
     --admin-pass "$${ADMIN_PASSWORD}" \
     --data-dir "/var/www/nextcloud/data"
 
-  # --- Configure S3 as primary storage ---
-  # NOTE: the class must be set as a sub-key, not the top-level value,
-  # or Nextcloud throws "No class given for objectstore" / crashes the mount.
+  # class must be a sub-key, not the top-level value, or Nextcloud throws
+  # "No class given for objectstore"
   sudo -u nginx php /var/www/nextcloud/occ config:system:set objectstore class \
     --value "OC\\Files\\ObjectStore\\S3"
   sudo -u nginx php /var/www/nextcloud/occ config:system:set objectstore arguments bucket \
@@ -55,24 +106,48 @@ if [ ! -f /var/www/nextcloud/config/config.php ]; then
     --value "false" --type boolean
   sudo -u nginx php /var/www/nextcloud/occ config:system:set objectstore arguments use_ssl \
     --value "true" --type boolean
-  # no key/secret set here on purpose — relies on the EC2 instance profile's IAM role
+  # no key/secret here on purpose — relies on the EC2 instance profile's IAM role
 
-  # --- Trusted domain (Elastic IP; swap for real domain once Phase 6 DNS is live) ---
+  # files_external ships with Nextcloud but isn't enabled by default
+  sudo -u nginx php /var/www/nextcloud/occ app:enable files_external
+
+  sudo -u nginx php /var/www/nextcloud/occ files_external:create \
+    "Migration" amazons3 amazons3::accesskey \
+    --config bucket="${migration_bucket}" \
+    --config hostname="s3.${aws_region}.amazonaws.com" \
+    --config region="${aws_region}" \
+    --config use_ssl=true \
+    --config use_path_style=false \
+    --config key="$${MIGRATION_ACCESS_KEY_ID}" \
+    --config secret="$${MIGRATION_SECRET_ACCESS_KEY}"
+
+  sudo -u nginx php /var/www/nextcloud/occ files:scan --all
+
+  # deletes on S3 storage crash Trashbin's move-to-trash handoff (upstream bug, #28) — disabled instance-wide, no undo/trash as a trade-off
+  sudo -u nginx php /var/www/nextcloud/occ app:disable files_trashbin
+
   sudo -u nginx php /var/www/nextcloud/occ config:system:set trusted_domains 1 \
     --value "${elastic_ip}"
 
-  # --- Optional: also trust a DNS name if provided (index 2, doesn't overwrite the IP) ---
   if [ -n "${domain_name}" ]; then
     sudo -u nginx php /var/www/nextcloud/occ config:system:set trusted_domains 2 \
       --value "${domain_name}"
   fi
+
+  # Nextcloud sits behind Cloudflare Tunnel (HTTPS at the edge, plain HTTP
+  # locally) — without trusting that, protocol detection is inconsistent
+  # between requests and corrupts session cookie encryption ("HMAC does not
+  # match", spinning logins, getting bounced back to the login screen).
+  sudo -u nginx php /var/www/nextcloud/occ config:system:set trusted_proxies 0 \
+    --value "127.0.0.1"
+  sudo -u nginx php /var/www/nextcloud/occ config:system:set overwriteprotocol \
+    --value "https"
 
   echo "Nextcloud install complete."
 else
   echo "Nextcloud already configured, skipping install."
 fi
 
-# --- Nextcloud theming (logo pulled from S3, correct nginx user) ---
 NC_DIR="/var/www/nextcloud"
 LOGO_PATH="$${NC_DIR}/branding/logo.png"
 
@@ -85,7 +160,6 @@ sudo -u nginx php occ theming:config name "OneVoice"
 sudo -u nginx php occ theming:config primary_color "#1a5d3a"
 sudo -u nginx php occ theming:config logo "$${LOGO_PATH}"
 
-# --- Add initial users (idempotent: skip existing) ---
 declare -A NEW_USERS=(
   ["jsomori"]="Joseph Somori"
   ["eayanwale"]="Enoch Ayanwale"

--- a/onevoice-storage/terraform/security.tf
+++ b/onevoice-storage/terraform/security.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "cloudtrail_logs" {
   bucket = "${var.organization}-${var.environment}-cloudtrail-logs"
-
+  force_destroy = true  # for dev/test environments, so "terraform destroy" works without manual cleanup
   tags = {
     Name = "${var.organization}-${var.environment}-cloudtrail-logs"
   }

--- a/onevoice-storage/terraform/vpc.tf
+++ b/onevoice-storage/terraform/vpc.tf
@@ -22,9 +22,10 @@ resource "aws_internet_gateway" "onevoice-igw" {
 # }
 
 resource "aws_subnet" "pub-a" {
-  vpc_id            = aws_vpc.onevoice-vpc.id
-  cidr_block        = var.subnet_cidrs.a
-  availability_zone = "${var.aws_region}a"
+  vpc_id                  = aws_vpc.onevoice-vpc.id
+  cidr_block              = var.subnet_cidrs.a
+  availability_zone       = "${var.aws_region}a"
+  map_public_ip_on_launch = true
 
   tags = {
     Name = "${var.organization}-${var.environment}-pub-a"


### PR DESCRIPTION
## Summary

Folds three things that only ever existed as manual SSH changes on prod back into version-controlled provisioning (`packer/setup.sh` + `terraform/scripts/user-data.sh`), so a rebuilt instance actually reproduces the live server instead of coming up broken:

- Cloudflare Tunnel (cloudflared)
- nginx rate limiting
- The Nextcloud MCP server + monthly maintenance-check timer

Closes #41, #42, #43.

### Additional fixes found while validating this in a sandbox environment

Standing this up end-to-end (rather than just trusting the diff) surfaced several more real, previously-undocumented gaps — included here since they were required to get a genuinely clean boot:

- **Migration bucket External Storage mount** — also only ever set up by hand, never scripted (`occ files_external:create` + `occ app:enable files_external`)
- **Reverse-proxy trust** (`trusted_proxies`, `overwriteprotocol`) — Nextcloud was never told to trust Cloudflare Tunnel, which was silently corrupting session cookies ("HMAC does not match", spinning logins, getting bounced back to the login screen)
- **Trashbin disabled** — S3-backed storage deletes crash Trashbin's move-to-trash handoff, a known upstream Nextcloud bug class; this is the root-caused fix for #28 (deletes go straight to the object store instead)
- **Sandbox/environment isolation infra**: Terraform workspace support (`data.tf`), environment-scoped EC2 key pair naming, auto-assigned public IPs in the public subnet, and `force_destroy` on the CloudTrail logs bucket — all needed to actually test any of the above safely without touching prod

## Test plan

- [x] `packer build` completes clean with all fixes baked in (previously required manual SSH patching to work at all — Packer file-provisioner directory bug, `fastcgi_split_path_info` regex bug, missing `git` dependency, and an nginx default-server conflict were all found and fixed along the way)
- [x] Full `terraform destroy` + `apply` of an isolated `sandbox` workspace (not just `-replace` on the instance — confirmed that alone isn't sufficient, since RDS persists and collides with a fresh `occ maintenance:install`)
- [x] `cloud-init` completes with no errors on a genuinely fresh boot
- [x] `curl https://<env>.knoch.dev/status.php` returns real Nextcloud JSON
- [x] MCP endpoint responds to a raw JSON-RPC `initialize` call, both directly on the instance (`127.0.0.1:8000`) and through the tunnel
- [x] Logged in via the web UI, confirmed Files/navigation work without session errors
- [x] Settings → Administration → External Storage shows the "Migration" mount
- [ ] Same validation against prod once merged — see `docs/deployment-runbook.md` for the full deploy sequence, and note `s3.tf`'s migration bucket needs `prevent_destroy` added before this touches prod (deliberately withheld during sandbox testing, see runbook Cautions)
