### PR TITLE
fix(aws): nginx routing/MIME gaps and the code-integrity failure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# core.autocrlf=true on Windows checkouts rewrites these to CRLF. A stray \r
+# in a shebang gives "bad interpreter: /bin/bash^M" on the server, and systemd
+# treats the \r as part of the value in a unit or EnvironmentFile. Pin LF.
+*.sh            text eol=lf
+*.service       text eol=lf
+*.timer         text eol=lf
+*.conf          text eol=lf
+*.env.example   text eol=lf

--- a/onevoice-storage/packer/setup.sh
+++ b/onevoice-storage/packer/setup.sh
@@ -40,6 +40,15 @@ server {
     client_max_body_size 512M;
     fastcgi_buffers 64 4K;
 
+    # Service-discovery endpoints. Without these, CalDAV/CardDAV clients cannot
+    # autodiscover — they probe /.well-known/caldav and get the 404 page.
+    # `location =` is an exact match and outranks the regex blocks below
+    # regardless of ordering.
+    location = /.well-known/carddav   { return 301 /remote.php/dav/; }
+    location = /.well-known/caldav    { return 301 /remote.php/dav/; }
+    location = /.well-known/webfinger { return 301 /index.php/.well-known/webfinger; }
+    location = /.well-known/nodeinfo  { return 301 /index.php/.well-known/nodeinfo; }
+
     location / {
         limit_req zone=nextcloud_limit burst=20 nodelay;
         rewrite ^ /index.php$request_uri;
@@ -53,10 +62,44 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         fastcgi_pass unix:/run/php-fpm/www.sock;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        # fastcgi_split_path_info sets $fastcgi_path_info, but stock
+        # fastcgi_params never forwards it. Routes that depend on PATH_INFO
+        # (WebDAV under /remote.php/dav/..., OCS) otherwise see an empty path.
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         include fastcgi_params;
     }
 
-    location ~ \.(?:css|js|mjs|svg|gif|png|jpg|ico|woff2?)$ {
+    # Must come AFTER the \.php block: nginx takes the first matching regex
+    # location, so placing this earlier swallows /ocs-provider/index.php and
+    # `try_files $uri/` then looks for "/ocs-provider/index.php/" and 404s the
+    # very file it needs to serve. ocm-provider is excluded — Nextcloud 30
+    # does not ship that directory.
+    location ~ ^/(?:updater|ocs-provider)(?:$|/) {
+        try_files $uri $uri/ =404;
+        index index.php;
+    }
+
+    # .mjs and .js.map have no entry in nginx's stock mime.types, so they are
+    # served as application/octet-stream and browsers refuse to execute them.
+    # `occ setupchecks` reports the .mjs case as a hard failure.
+    #
+    # Use per-location default_type, NOT a `types { }` block: a types block
+    # REPLACES the inherited MIME map for its context rather than extending it,
+    # which turns every .css into octet-stream and renders the UI unstyled.
+    # Regex locations match in order, so these precede the general block.
+    location ~ \.mjs$ {
+        default_type text/javascript;
+        expires 30d;
+        access_log off;
+    }
+
+    location ~ \.map$ {
+        default_type application/json;
+        expires 30d;
+        access_log off;
+    }
+
+    location ~ \.(?:css|js|svg|gif|png|jpg|ico|woff2?)$ {
         expires 30d;
         access_log off;
     }

--- a/onevoice-storage/terraform/scripts/user-data.sh
+++ b/onevoice-storage/terraform/scripts/user-data.sh
@@ -149,9 +149,22 @@ else
 fi
 
 NC_DIR="/var/www/nextcloud"
-LOGO_PATH="$${NC_DIR}/branding/logo.png"
 
-mkdir -p "$${NC_DIR}/branding"
+# Stage the logo OUTSIDE the Nextcloud root. Writing it to
+# <nextcloud>/branding/logo.png makes `occ integrity:check-core` report
+#   EXTRA_FILE: branding/logo.png
+# which turns Administration > Overview's code-integrity check into a hard
+# failure. Nextcloud's signed manifest covers the whole tree, so ANY extra
+# file under it fails — the logo is not special. theming:config reads the
+# image and stores its own copy in appdata, so the source need not live there.
+BRANDING_DIR="/var/lib/onevoice/branding"
+LOGO_PATH="$${BRANDING_DIR}/logo.png"
+
+mkdir -p "$${BRANDING_DIR}"
+
+# Drop the in-tree copy left behind by earlier deploys of this script.
+rm -rf "$${NC_DIR}/branding"
+
 aws s3 cp "s3://${s3_bucket}/branding/logo.png" "$${LOGO_PATH}" --region "${aws_region}"
 chown nginx:nginx "$${LOGO_PATH}"
 


### PR DESCRIPTION
Three defects found while porting this deployment to a Bluehost VPS (#57) that exist on the EC2 path too. Each was fixed and verified on that live host first, then ported here.

**Nothing here changes the running EC2 instance.** `setup.sh` takes effect on the next `packer build`, `user-data.sh` on the next instance launch.

## What was wrong

| Defect | Symptom on the live instance |
| --- | --- |
| No `.well-known/{carddav,caldav}` redirects | CalDAV/CardDAV clients cannot autodiscover — they probe `/.well-known/caldav` and get the 404 page. `occ setupchecks` warns. |
| `PATH_INFO` never forwarded to fastcgi | `fastcgi_split_path_info` sets `$fastcgi_path_info`, but stock `fastcgi_params` does not pass it on, so routes depending on it see an empty path. |
| `/ocs-provider/` unroutable | Returns 404; federated-sharing discovery fails. |
| `.mjs` served as `application/octet-stream` | **Hard** setupcheck failure: *"This will break some apps"* — browsers refuse to execute modules with the wrong MIME type. |
| Logo written inside the Nextcloud root | `occ integrity:check-core` reports `EXTRA_FILE: branding/logo.png`; Administration → Overview shows a **failed** code-integrity check. |

The last one is worth spelling out: Nextcloud's signed manifest covers the entire tree, so *any* extra file under it fails integrity — the logo is not special. `theming:config` reads the image and stores its own copy in appdata, so the source never needed to live there. The script now stages it in `/var/lib/onevoice/branding` and removes in-tree copies left by earlier deploys.

## Two ordering traps, both hit for real

Recording these because both produce symptoms that point away from the cause:

1. **The `ocs-provider` block must come *after* the `\.php` location.** nginx takes the first matching regex location, so placing it earlier swallows `/ocs-provider/index.php`, and `try_files $uri/` then looks for `/ocs-provider/index.php/` and 404s the very file it needs to serve.

2. **`.mjs` is fixed with per-location `default_type`, not a `types { }` block.** A `types` block *replaces* the inherited MIME map for its context rather than extending it. The first attempt at this fix declared `js`, `mjs` and `map` — and thereby deleted `text/css`, serving every stylesheet as `application/octet-stream` and rendering the entire UI unstyled. `nginx -t` passes happily; the config is valid, it just describes a server that knows three file types. Observed, not theorised.

`Strict-Transport-Security` is deliberately **not** added — that belongs with the TLS termination config, not here.

## `.gitattributes`

Pins LF for `*.sh`, `*.service`, `*.timer`, `*.conf`. With `core.autocrlf=true` these scripts check out CRLF on Windows, and **Packer uploads `setup.sh` from the working tree** — a stray CR in a shebang makes the kernel reject the interpreter. The two touched files are renormalised in this commit.

## Verification

- The rendered `setup.sh` server block passes a real `nginx -t` (extracted from the heredoc and tested against the nginx binary, not eyeballed).
- Block ordering asserted programmatically (`.php` at line 27, `ocs-provider` at line 43).
- Asserted no `types { }` block survives.
- On the Bluehost host running the equivalent config: `.well-known/*` → 301, `/ocs-provider/` → 200 with correct OCS JSON, `/remote.php/dav/` → 401 (auth required, i.e. routing works), CSS → `text/css`, `.mjs` → `text/javascript`, `integrity:check-core` clean.

**Not verified against an actual AMI build** — I have no way to run `packer build` from here. Worth a build before merging, or at least before the next instance replace.

Closes the first two follow-ups listed in #57.
