### PR TITLE
infra(bluehost): port Nextcloud deployment to AlmaLinux 10 VPS (#57)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# core.autocrlf=true on Windows checkouts rewrites these to CRLF. A stray \r
+# in a shebang gives "bad interpreter: /bin/bash^M" on the server, and systemd
+# treats the \r as part of the value in a unit or EnvironmentFile. Pin LF.
+*.sh            text eol=lf
+*.service       text eol=lf
+*.timer         text eol=lf
+*.conf          text eol=lf
+*.env.example   text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@
 **.pem
 **/keys/*
 !**/keys/*.pub
+
+# Filled-in deployment config. Holds DB/admin passwords, the Cloudflare tunnel
+# token and object-storage keys — the values SSM used to hold on the EC2 side.
+# Only the .example template belongs in git.
+onevoice-storage/bluehost/onevoice.env
+**/onevoice.env
+!**/onevoice.env.example

--- a/onevoice-storage/bluehost/README.md
+++ b/onevoice-storage/bluehost/README.md
@@ -1,0 +1,335 @@
+# OneVoice Nextcloud on a Bluehost VPS (AlmaLinux 10)
+
+A port of the AWS deployment to a plain VPS. Same Nextcloud, same theming,
+same seed users, same Cloudflare Tunnel front door — none of the AWS control
+plane.
+
+## Why there is no image to copy
+
+The AMI cannot be moved to Bluehost, for two independent reasons:
+
+1. **`aws ec2 export-image` rejects it.** VM Import/Export refuses images
+   derived from AWS-provided Linux AMIs. `nextcloud.pkr.hcl` builds from
+   `al2023-ami-*`, so the export is blocked at the licensing check.
+2. **Bluehost VPS does not accept custom disk images.** You get their OS
+   templates. That is why this box is AlmaLinux 10 and not a booted copy of
+   the AMI.
+
+Even with both solved, the AMI is the wrong artifact. Roughly half its value
+is AWS-coupled — IMDS instance profile for S3, SSM Parameter Store for every
+secret, an RDS endpoint. It would boot and immediately fail.
+
+**The scripts are the portable artifact.** These are refactors of the two that
+already build the EC2 host:
+
+| AWS | Bluehost | Role |
+| --- | --- | --- |
+| `packer/setup.sh` (Packer, bake time) | `provision.sh` | OS, packages, nginx/php config, systemd units. No secrets. |
+| `terraform/scripts/user-data.sh` (cloud-init, first boot) | `configure.sh` | Database, `occ maintenance:install`, theming, users. All secrets. |
+| SSM Parameter Store + `templatefile()` vars | `/etc/onevoice/onevoice.env` | Configuration and secret input. |
+
+The two-phase split is kept even though a VPS has no bake step: `provision.sh`
+needs no credentials and is safe to re-run for OS maintenance, `configure.sh`
+holds everything that touches secrets and application state. Both are
+idempotent. `bootstrap.sh` runs them in order.
+
+## Current deployment: 50.6.226.196
+
+The working config lives in `onevoice.env` (gitignored — it holds passwords and
+object-storage keys). Shape of it:
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| Trusted domains | `50.6.226.196` only | `configure.sh` deletes and rewrites the array, so this is the exact list. |
+| Access | plain HTTP on the raw IP | No tunnel yet, so `overwriteprotocol` and `trusted_proxies` are **cleared**, not set to https. |
+| `OPEN_HTTP_PORT` | `true` | Needed to reach port 80; AlmaLinux runs firewalld by default. |
+| Database | local MariaDB | Not RDS — see below. |
+| Primary storage | local disk | Not the prod S3 bucket — see below. |
+| External storage | Backblaze B2 via S3 API | `s3.us-east-005.backblazeb2.com`, region `us-east-005`. |
+| Cloudflared / MCP / maintenance | off | Each needs a value that does not exist yet. |
+
+Cloudflared and MCP are off because both need something a running instance
+produces: a tunnel hostname, and an app password minted from Settings >
+Security. Fill those in and re-run `configure.sh` — it is idempotent, and the
+install block is skipped once `config.php` exists.
+
+**Why the database is local and not RDS.** Your RDS instance holds the
+*production* database. Pointing this box at it would not produce a clone — it
+would attach a second Nextcloud to prod's `oc_filecache` with a different data
+directory, corrupting both. It would also require making RDS publicly
+accessible, and Nextcloud issues dozens of queries per page render, so
+cross-internet round trips make the UI crawl and you pay egress on each one.
+
+## Install
+
+Clone the repo on the server and `scp` **only** the secrets file. Don't scp
+just `bluehost/` on its own — the scripts read siblings outside it:
+
+- `provision.sh` installs from `bluehost/files/` (unit files, `rate-limit.conf`,
+  the maintenance script), so that subdirectory must come along;
+- `configure.sh` defaults `LOGO_SRC` to `../terraform/assets/logo.png`, which
+  lives **outside** `bluehost/`. Copy only `bluehost/` and theming silently
+  falls back to name and colour with no logo.
+
+On the VPS:
+
+```bash
+sudo dnf install -y git
+git clone https://github.com/eayanwale/onevoice-storage.git
+cd onevoice-storage/onevoice-storage/bluehost
+```
+
+From your workstation — `onevoice.env` is gitignored, so it is the one file
+that has to travel out of band:
+
+```bash
+scp onevoice.env root@50.6.226.196:/etc/onevoice/onevoice.env
+```
+
+Back on the VPS:
+
+```bash
+sudo mkdir -p /etc/onevoice          # if scp failed on a missing directory
+sudo chown root:root /etc/onevoice/onevoice.env
+sudo chmod 600       /etc/onevoice/onevoice.env
+
+sudo ./bootstrap.sh
+```
+
+Then browse to `http://50.6.226.196`.
+
+If you would rather not clone on the server, copy the repo subtree from your
+workstation instead — the whole `onevoice-storage/` directory, not just
+`bluehost/`:
+
+```bash
+scp -r onevoice-storage root@50.6.226.196:/opt/onevoice-storage
+```
+
+## Two ways this clone can damage production
+
+Both are guarded in `configure.sh`, but understand them before you edit the
+env file.
+
+### Sharing the primary S3 bucket destroys prod file content
+
+A Nextcloud primary object store keys every object as `urn:oid:<fileid>`,
+where `<fileid>` is a row id **in that instance's own database**. This clone
+starts with an empty database, so it allocates fileid 1, 2, 3… and writes
+`urn:oid:1`, `urn:oid:2` — straight over prod's objects. Recovery means S3
+version rollback, object by object.
+
+`OBJECT_STORE=local` (the default) makes this structurally impossible. If you
+set `OBJECT_STORE=s3`, use a **new, empty bucket**. `configure.sh` refuses any
+bucket name containing `prod` unless you also set
+`I_UNDERSTAND_SHARED_BUCKET=yes`.
+
+This does **not** apply to `ENABLE_MIGRATION_MOUNT` — external storage
+addresses objects by real path, not by fileid, so sharing that bucket is safe.
+That is why the Backblaze mount is fine to point anywhere.
+
+### Backblaze: bucket NAME, not bucket ID
+
+The B2 console shows a 24-hex-character bucket **ID** (e.g.
+`f3dbc2d8047a262da4040313`). That identifier belongs to B2's native API. The
+S3-compatible endpoint addresses buckets by **name** — the human-readable one
+you chose at creation — and returns 404 for an ID.
+
+`configure.sh` verifies the mount right after creating it and prints a warning
+naming this as the likely cause rather than leaving a mount that just appears
+empty in the UI. It warns and continues; Nextcloud still installs. To fix
+without a full re-run:
+
+```bash
+sudo -u nginx php /var/www/nextcloud/occ files_external:list
+sudo -u nginx php /var/www/nextcloud/occ files_external:option <id> bucket <name>
+sudo -u nginx php /var/www/nextcloud/occ files_external:verify <id>
+```
+
+### Reusing the tunnel token hijacks the prod hostname
+
+A Cloudflare tunnel token identifies a *tunnel*, not a machine. Running the
+prod token here registers this VPS as a second replica, and Cloudflare will
+round-robin `onevoice.knoch.dev` between the EC2 box and this one — users get
+randomly served whichever answers. Create a new tunnel and hostname.
+
+## What changed, and why
+
+### Replaced outright
+
+- **SSM Parameter Store → `/etc/onevoice/onevoice.env`.** All eight
+  `aws ssm get-parameter --with-decryption` calls. Root-owned, `0600`.
+- **RDS → local MariaDB.** `DB_MODE=local` installs it and writes
+  `/etc/my.cnf.d/nextcloud.cnf` with `READ-COMMITTED` + `ROW` binlog, which RDS
+  defaulted close enough to that the EC2 build never stated it. The database is
+  created `utf8mb4` up front rather than converted later.
+- **S3 instance profile → explicit IAM access key.** The EC2 script
+  *deliberately* omitted `objectstore arguments key/secret` so the SDK would
+  pick up the instance profile from IMDS. There is no IMDS on a VPS, so a key
+  is mandatory when `OBJECT_STORE=s3`.
+- **`aws ssm put-parameter` for seed-user passwords →
+  `/root/onevoice-user-passwords.txt`** (`0600`).
+- **`aws s3 cp s3://…/branding/logo.png` → the local repo copy** at
+  `terraform/assets/logo.png`.
+- **SNS alerting → optional.** With no ambient AWS identity, the maintenance
+  script logs instead of publishing unless credentials are present.
+- **`ec2-user` → `SERVICE_USER` (default `onevoice`),** created by
+  `provision.sh`. The systemd units ship with `__SERVICE_USER__` /
+  `__SERVICE_HOME__` placeholders instead of a hardcoded `/home/ec2-user`.
+- **Terraform `templatefile()` → plain bash.** The `$${VAR}` escaping that
+  `user-data.sh` needed to hide bash variables from Terraform interpolation is
+  gone; everything is ordinary `"$VAR"`.
+
+### New, because AlmaLinux is not Amazon Linux
+
+- **SELinux.** The single biggest difference and the one most likely to cost
+  you an afternoon. AL2023 boots *permissive*; AlmaLinux 10 boots
+  **enforcing**. Without the `semanage fcontext` rules and
+  `httpd_can_network_connect` / `_db` / `_memcache` booleans in `provision.sh`,
+  nginx cannot read the docroot, php-fpm cannot write `config/`, and every
+  outbound S3 call is denied.
+- **firewalld.** Runs by default here; absent on AL2023, where inbound
+  filtering was the EC2 security group's job — a Terraform resource, not a
+  script concern. Left closed by default: Cloudflare Tunnel is outbound-only
+  and needs no inbound port. `OPEN_HTTP_PORT=true` opens 80 for raw-IP
+  debugging.
+- **PHP 8.3 from AppStream, not `php8.2-*`.** AlmaLinux 10 (RHEL 10 rebuild)
+  dropped modularity and ships plain `php-*` packages at 8.3, inside Nextcloud
+  30's supported 8.1–8.3 range.
+- **The stock `nginx.conf` default server is commented out.** AL2023's has no
+  such block. Done by brace-counting `awk`, not a `sed` line range — the stock
+  block contains nested `location { }` blocks, so a `/server {/,/^\s*}/` range
+  terminates on the first nested closing brace and leaves a broken file.
+- **Checksum verification on the Nextcloud tarball.** Packer downloaded at
+  bake time on a trusted network; this downloads at deploy time.
+
+### Deliberate additions beyond parity
+
+Both are flags, both default on. Turn them off for strict parity.
+
+- **`ENABLE_REDIS`** — distributed file locking and local cache. The EC2 build
+  has neither and falls back to DB-backed locking.
+- **`ENABLE_CRON_TIMER`** — a systemd timer running `cron.php` every 5 minutes,
+  plus `occ background:cron`. The EC2 build leaves background jobs on **AJAX**,
+  meaning they only fire when someone loads a page; on a quiet instance file
+  scans, share expiry, preview generation and cleanup all stall.
+
+`ENABLE_MAINTENANCE_TIMER` defaults **off**, in the other direction: the EC2
+host already runs that timer on the 15th, and enabling it here too means two
+hosts opening two near-identical issues and PRs each month. If you do enable
+it, branches and titles are tagged with `ENVIRONMENT` so the two are
+distinguishable, and the service account gets a scoped
+`/etc/sudoers.d/onevoice-maintenance` rather than the blanket NOPASSWD sudo
+`ec2-user` had from the AMI.
+
+### Carried over unchanged, including its warts
+
+The nginx server block is byte-identical to the one baked into the AMI, so
+this is genuinely a clone. It has two known gaps, present on **both**
+deployments and not silently patched here:
+
+- no `.well-known/carddav` + `caldav` redirects — Nextcloud files a setup
+  warning, and some DAV clients need them;
+- no `fastcgi_param PATH_INFO` — matters for a few app routes.
+
+`files_trashbin` is still disabled, but now only when `OBJECT_STORE=s3`, since
+the upstream bug (#28) is a move-to-trash handoff failure specific to object
+storage. On local disk the clone keeps working trash.
+
+## Verifying
+
+```bash
+sudo -u nginx php /var/www/nextcloud/occ status
+sudo -u nginx php /var/www/nextcloud/occ setupchecks
+systemctl status nginx php-fpm cloudflared nextcloud-mcp
+systemctl list-timers 'nextcloud-*'
+sudo cat /root/onevoice-user-passwords.txt
+```
+
+If pages load by raw IP but not by hostname, the tunnel is the suspect:
+`journalctl -u cloudflared -f`. If you get "HMAC does not match" or a login
+that bounces back to the login screen, `trusted_proxies` / `overwriteprotocol`
+did not apply — the same failure mode documented in `user-data.sh`.
+
+## Local disk budget (50 GB volume)
+
+Why primary storage is local disk and not B2: **`knoch-nextcloud-storage`
+already contains files.** A primary object store is a flat namespace keyed
+`urn:oid:<fileid>` from Nextcloud's own database — it has no concept of the
+real paths already in the bucket, so every existing file would become
+permanently unreadable through Nextcloud. The admin manual: *"Configuring a
+primary object store on an existing Nextcloud instance will make all existing
+files on the instance inaccessible."* External storage addresses objects by
+real path and preserves them, so that is the correct backend here. One bucket
+cannot do both — as an object store its contents are opaque blobs, and
+mounting that same bucket in the UI would let users delete them.
+
+**The B2 mount does not keep Nextcloud off the local volume.** Fixed cost:
+
+| Component | Approx. |
+| --- | --- |
+| AlmaLinux 10 base | 2–3 GB |
+| nginx, PHP + extensions, MariaDB, Valkey | ~1 GB |
+| Nextcloud 30 source (extracted) | ~700 MB |
+| Fresh Nextcloud schema | ~60 MB |
+| **Total** | **~4–5 GB, leaving ~45 GB** |
+
+Four things then grow on local disk, and the first two are what matter:
+
+1. **Previews — the big one.** Nextcloud renders thumbnails for files *on the
+   B2 mount* and caches them locally in
+   `data/appdata_<instanceid>/preview`. Rough order: 100–500 KB per previewed
+   file across the size variants, so ~50k images is 5–25 GB. `configure.sh`
+   caps this (`preview_max_x/y` 2048, skip images over 50 MB, JPEG quality 80).
+2. **Chunked upload staging.** Large uploads are assembled in
+   `data/<user>/uploads` *before* being written to the destination — including
+   uploads destined for B2. So the largest single file anyone can upload is
+   bounded by free local disk, regardless of B2 capacity.
+3. **`oc_filecache` in MariaDB** — one row per file, including every object on
+   the B2 mount after `files:scan`. Roughly 1 KB per file with indexes: 100k
+   files ≈ 100 MB, 1M files ≈ 1 GB.
+4. **`nextcloud.log`** — capped at 100 MB with rotation by `configure.sh`.
+
+Practical guidance: have people work **inside the mounted folder** so file
+content goes to B2. Anything stored elsewhere in Nextcloud consumes the 45 GB.
+Watch it with `df -h /` and
+`du -sh /var/www/nextcloud/data/appdata_*/preview`.
+
+## EL10 platform facts this depends on
+
+Checked against package metadata rather than assumed, because AlmaLinux 10 is
+not a small step from Amazon Linux 2023:
+
+| Thing | Reality on AlmaLinux 10 | Consequence |
+| --- | --- | --- |
+| PHP | `php` **is 8.3** (10.1 ships 8.3.26); 8.4 is a separately named `php8.4` package, **not** a module stream — EL10 has no DNF modules at all | `dnf install php` lands in Nextcloud 30's supported range. Do not add `php8.4`. |
+| zip extension | `php-pecl-zip` (1.22.3-5.el10). A plain `php-zip` exists on Mageia/OpenMandriva but **not** on EL | Several popular guides say `php-zip`; they are wrong for EL. |
+| curl extension | bundled in `php-common`, no separate `php-curl` | Same guides list `php-curl`, which does not resolve. |
+| Redis | **removed.** Redis Labs left open source at 7.4 (RSALv2/SSPLv1), so EL10 ships **Valkey** | `dnf install redis` fails outright. Valkey is wire/command/on-disk compatible, so the PHP client and `\OC\Memcache\Redis` are unchanged. |
+| MariaDB | 10.11 in AppStream as `mariadb-server` | `mysql.user` is a non-updatable view (10.4+), so classic hardening snippets using `DELETE FROM mysql.user` fail. |
+| SELinux | **enforcing** (AL2023 is permissive) | Without the fcontext rules and `httpd_can_network_*` booleans, nginx cannot read the docroot and php-fpm cannot write `config/`. |
+| firewalld | present and running (absent on AL2023) | Inbound filtering was the EC2 security group's job; here it is a host concern. |
+
+Rather than trusting any package name, `provision.sh` verifies the **loaded
+extensions** after install (`php -m`), attempts one automatic repair under both
+naming conventions, and fails with the specific missing list plus the
+`dnf provides '*/<ext>.so'` command to resolve it.
+
+## Remaining risks on first run
+
+**1. The 50 GB local volume.** See the budget below — the B2 mount does *not*
+keep Nextcloud off local disk, and previews are the thing that will fill it.
+
+**2. Bluehost's own network firewall.** `provision.sh` opens 80/tcp in
+firewalld, but some VPS products also filter upstream in the control panel. If
+the box answers `curl localhost` but not the public IP, that's where to look.
+
+**3. `php-pecl-imagick`** is best-effort (EPEL on EL10). Nextcloud runs without
+it — admin warning only.
+
+**4. Valkey not running.** `configure.sh` checks both that the PHP redis
+extension loaded *and* that something answers on 127.0.0.1:6379 before setting
+`memcache.locking`. Pointing file locking at a dead cache server fails every
+request, turning "slower without caching" into "completely unreachable".
+
+These scripts have not been run against a live AlmaLinux 10 host.

--- a/onevoice-storage/bluehost/bootstrap.sh
+++ b/onevoice-storage/bluehost/bootstrap.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# bootstrap.sh — run both halves in order.
+#
+# On EC2 these two phases were separated by time and mechanism: provision.sh's
+# ancestor ran at AMI bake time under Packer, configure.sh's ancestor ran at
+# first boot as cloud-init user data. A Bluehost VPS has no bake step, so they
+# run back to back here — but they stay separate files, because the split is
+# still useful: provision.sh needs no secrets and is safe to re-run for OS
+# maintenance, configure.sh holds everything that touches credentials and
+# application state.
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/provision.sh"
+"$SCRIPT_DIR/configure.sh"

--- a/onevoice-storage/bluehost/configure.sh
+++ b/onevoice-storage/bluehost/configure.sh
@@ -472,6 +472,170 @@ occ config:system:set maintenance_window_start \
 log "Adding missing database indices"
 occ db:add-missing-indices
 
+# ---------------------------------------------------------------------------
+# Outbound email
+# ---------------------------------------------------------------------------
+# Nextcloud fails SILENTLY when this is unconfigured — no error in the UI, the
+# mail simply never goes. Password resets are the case that bites, because the
+# user just sees "check your email" forever.
+#
+# mail_from_address is the LOCAL PART ONLY; Nextcloud joins it with
+# mail_domain. Both must be set or sending is refused outright.
+if [[ "${ENABLE_SMTP:-false}" == "true" ]]; then
+  require SMTP_HOST
+  require SMTP_USER
+  require SMTP_PASSWORD
+  require MAIL_DOMAIN
+
+  log "Configuring outbound email via ${SMTP_HOST}:${SMTP_PORT:-587}"
+
+  occ config:system:set mail_smtpmode     --value smtp
+  occ config:system:set mail_smtphost     --value "$SMTP_HOST"
+  occ config:system:set mail_smtpport     --value "${SMTP_PORT:-587}" --type integer
+  occ config:system:set mail_smtpsecure   --value "${SMTP_SECURE:-tls}"
+  occ config:system:set mail_smtpauth     --value "${SMTP_AUTH:-true}" --type boolean
+  occ config:system:set mail_smtpname     --value "$SMTP_USER"
+  occ config:system:set mail_smtppassword --value "$SMTP_PASSWORD"
+  occ config:system:set mail_from_address --value "${MAIL_FROM_ADDRESS:-noreply}"
+  occ config:system:set mail_domain       --value "$MAIL_DOMAIN"
+
+  echo "    from: ${MAIL_FROM_ADDRESS:-noreply}@${MAIL_DOMAIN}"
+
+  # Reachability check only — proves the relay is routable and not blocked.
+  # It does NOT prove the credentials work; use Settings > Administration >
+  # Basic settings > "Send email" for that, which surfaces the real SMTP error.
+  if timeout 8 bash -c "echo > /dev/tcp/${SMTP_HOST}/${SMTP_PORT:-587}" 2>/dev/null; then
+    echo "    relay reachable on ${SMTP_PORT:-587}"
+  else
+    echo "WARNING: cannot open ${SMTP_HOST}:${SMTP_PORT:-587} from this host.
+      Mail will not send. Check outbound filtering, then retry with:
+        timeout 8 bash -c 'echo > /dev/tcp/${SMTP_HOST}/${SMTP_PORT:-587}'" >&2
+  fi
+else
+  log "Outbound email not configured (ENABLE_SMTP=false)"
+  echo "    Nextcloud cannot send password resets until this is set."
+fi
+
+# ---------------------------------------------------------------------------
+# Camera RAW mimetype alias
+# ---------------------------------------------------------------------------
+# Nextcloud ships a mismatch between its two mimetype config files:
+#
+#   mimetypemapping.dist.json : "arw": ["image/x-dcraw"]        <- what files get
+#   mimetypealiases.dist.json : "application/x-dcraw": "image"  <- what is aliased
+#
+# The alias that classifies a mimetype as an *image* is keyed to
+# application/x-dcraw, but the extension mapping produces image/x-dcraw. They
+# never meet, so the web UI never treats .arw/.cr2/.nef/.dng/.orf/.raf as
+# images: no thumbnail is requested and clicking one downloads it instead of
+# opening the viewer. Server-side preview generation is fine — the frontend
+# simply never asks.
+#
+# config/ is the supported override location and is not covered by the signed
+# manifest, so this does not affect integrity:check-core (verified).
+if [[ "${FIX_RAW_MIMETYPE:-true}" == "true" ]]; then
+  log "Aliasing image/x-dcraw to image (camera RAW previews)"
+
+  ALIAS_FILE="$NC/config/mimetypealiases.json"
+  if [[ ! -f "$ALIAS_FILE" ]]; then
+    cat > "$ALIAS_FILE" <<'EOF'
+{
+    "image/x-dcraw": "image"
+}
+EOF
+    chown nginx:nginx "$ALIAS_FILE"
+    chmod 640 "$ALIAS_FILE"
+  else
+    echo "    $ALIAS_FILE already present, leaving it alone"
+  fi
+
+  # Regenerates core/js/mimetypelist.js, which is what the frontend reads.
+  # Without this the alias exists in PHP but the browser never sees it.
+  occ maintenance:mimetype:update-js
+
+  # Re-tag rows scanned before the alias/app existed.
+  occ maintenance:mimetype:update-db --repair-filecache
+fi
+
+# ---------------------------------------------------------------------------
+# Camera RAW viewer patches
+# ---------------------------------------------------------------------------
+# Two hand-edits that make clicking a RAW file OPEN it instead of downloading
+# it. Both were applied by hand on the EC2 box on 2026-07-18 and recorded
+# nowhere — rediscovering them cost about an hour, which is the entire reason
+# they are scripted here.
+#
+# Neither is optional: the first alone registers a handler the Viewer refuses
+# to use, the second alone has nothing to register.
+#
+#   1. camerarawpreviews/js/register-viewer.js
+#      Stock file registers its handler behind an `if (OCA.Viewer)` guard, but
+#      is loaded via Util::addInitScript as a DEFERRED CLASSIC script while the
+#      Viewer's own bundle is an ES MODULE later in the document. Deferred
+#      classic and module scripts execute in document order, so the guard is
+#      always false and the handler never registers. Replaced with a version
+#      that polls until OCA.Viewer exists.
+#
+#   2. viewer/js/viewer-main.mjs
+#      The Viewer's supported-image mimetype array does not include
+#      image/x-dcraw, so even a correctly registered handler is ignored.
+#
+# COSTS, both accepted and matching EC2:
+#   - camerarawpreviews is signed, so `occ integrity:check-app` reports
+#     INVALID_HASH for it. Core integrity (integrity:check-core) is unaffected.
+#   - An app update to either app silently reverts its patch and RAW files go
+#     back to downloading. This block re-applies on every run, so re-running
+#     configure.sh after any app update restores them.
+#
+# Pristine originals are kept alongside as *.stock.bak (first run only).
+if [[ "${FIX_RAW_VIEWER:-true}" == "true" ]]; then
+  RV="$NC/apps/camerarawpreviews/js/register-viewer.js"
+  VM="$NC/apps/viewer/js/viewer-main.mjs"
+  RV_SRC="$SCRIPT_DIR/files/camerarawpreviews-register-viewer.js"
+
+  if [[ ! -f "$RV" ]]; then
+    echo "NOTE: camerarawpreviews not installed; skipping RAW viewer patches."
+    echo "      Install it with: occ app:install camerarawpreviews"
+  else
+    log "Patching camera RAW viewer support"
+
+    # --- patch 1: register-viewer.js -------------------------------------
+    if [[ ! -f "$RV_SRC" ]]; then
+      echo "WARNING: $RV_SRC missing; cannot patch register-viewer.js" >&2
+    elif cmp -s "$RV_SRC" "$RV"; then
+      echo "    register-viewer.js already patched"
+    else
+      [[ -f "$RV.stock.bak" ]] || cp -a "$RV" "$RV.stock.bak"
+      install -o nginx -g nginx -m 0644 "$RV_SRC" "$RV"
+      echo "    register-viewer.js patched (stock kept as register-viewer.js.stock.bak)"
+    fi
+
+    # --- patch 2: viewer-main.mjs ----------------------------------------
+    # Matched against the literal mimetype array in the minified bundle. If a
+    # Viewer update changes that array, the substitution silently matches
+    # nothing — so the result is verified rather than assumed. Silent failure
+    # is exactly how this bug hid for a month.
+    VIEWER_MIMES='"image/apng","image/bmp","image/gif","image/jpeg","image/png","image/svg+xml","image/webp","image/x-icon"'
+    if [[ ! -f "$VM" ]]; then
+      echo "WARNING: $VM not found; Viewer app missing?" >&2
+    elif grep -q '"image/x-dcraw"' "$VM"; then
+      echo "    viewer-main.mjs already claims image/x-dcraw"
+    else
+      [[ -f "$VM.stock.bak" ]] || cp -a "$VM" "$VM.stock.bak"
+      sed -i "s|${VIEWER_MIMES}|${VIEWER_MIMES},\"image/x-dcraw\"|g" "$VM"
+      chown nginx:nginx "$VM"
+      if grep -q '"image/x-dcraw"' "$VM"; then
+        echo "    viewer-main.mjs patched (stock kept as viewer-main.mjs.stock.bak)"
+      else
+        echo "WARNING: could not patch viewer-main.mjs — the mimetype array no
+      longer matches the expected literal, probably because the Viewer app was
+      updated. RAW files will download instead of opening. Re-derive the array
+      with:  grep -o '\"image/apng\"[^]]*' $VM" >&2
+      fi
+    fi
+  fi
+fi
+
 log "Applying OneVoice theming"
 
 # Stage the logo OUTSIDE the Nextcloud root. The EC2 build writes it to

--- a/onevoice-storage/bluehost/configure.sh
+++ b/onevoice-storage/bluehost/configure.sh
@@ -461,9 +461,35 @@ occ config:app:set preview jpeg_quality --value "${PREVIEW_JPEG_QUALITY:-80}"
 occ config:system:set log_rotate_size \
   --value "${LOG_ROTATE_BYTES:-104857600}" --type integer
 
+# Run the heavy daily background jobs at a quiet hour instead of during the
+# working day. Nextcloud warns when this is unset. Value is a UTC hour.
+occ config:system:set maintenance_window_start \
+  --value "${MAINTENANCE_WINDOW_START_UTC:-2}" --type integer
+
+# Optional indices Nextcloud adds over time but never applies automatically,
+# because on a large instance the ALTER can take a while. Cheap here and it
+# clears a standing admin warning.
+log "Adding missing database indices"
+occ db:add-missing-indices
+
 log "Applying OneVoice theming"
-LOGO_PATH="$NC/branding/logo.png"
-mkdir -p "$NC/branding"
+
+# Stage the logo OUTSIDE the Nextcloud root. The EC2 build writes it to
+# <nextcloud>/branding/logo.png, which `occ integrity:check-core` reports as
+#   EXTRA_FILE: branding/logo.png
+# and that turns Administration > Overview's code-integrity check into a hard
+# failure. Nextcloud's signed manifest covers the whole tree, so ANY extra file
+# under it fails — the logo is not special. theming:config reads the file and
+# stores its own copy in appdata, so the source does not need to live there.
+BRANDING_DIR="/var/lib/onevoice/branding"
+LOGO_PATH="${BRANDING_DIR}/logo.png"
+mkdir -p "$BRANDING_DIR"
+
+# Clean up the in-tree copy left by an earlier run of this script.
+if [[ -d "$NC/branding" ]]; then
+  echo "    removing in-tree $NC/branding (fails integrity check)"
+  rm -rf "$NC/branding"
+fi
 
 # The EC2 build pulled this with `aws s3 cp s3://<bucket>/branding/logo.png`,
 # which needed the instance profile. Out here the file ships with the repo.

--- a/onevoice-storage/bluehost/configure.sh
+++ b/onevoice-storage/bluehost/configure.sh
@@ -1,0 +1,601 @@
+#!/bin/bash
+#
+# configure.sh — application configuration for OneVoice Nextcloud on a
+# Bluehost AlmaLinux 10 VPS.
+#
+# Refactor of onevoice-storage/terraform/scripts/user-data.sh, which ran once
+# at EC2 first boot as a Terraform templatefile().
+#
+# Two things changed structurally:
+#
+#   1. No SSM. Every `aws ssm get-parameter --with-decryption` call is now a
+#      variable sourced from /etc/onevoice/onevoice.env (root:root 0600).
+#   2. No templatefile(). Terraform's ${db_host} / ${s3_bucket} interpolation
+#      is gone, and with it the $${VAR} double-dollar escaping that the
+#      original needed to keep bash variables away from Terraform. Everything
+#      here is plain bash "$VAR".
+#
+# Idempotent: safe to re-run. The install block is skipped once config.php
+# exists, exactly as in the original.
+#
+#   sudo ./configure.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${ENV_FILE:-/etc/onevoice/onevoice.env}"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "configure.sh must run as root." >&2
+  exit 1
+fi
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing $ENV_FILE. Copy onevoice.env.example there and fill it in." >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+# ---------------------------------------------------------------------------
+# Defaults + validation
+# ---------------------------------------------------------------------------
+ORGANIZATION="${ORGANIZATION:-onevoice}"
+ENVIRONMENT="${ENVIRONMENT:-bluehost}"
+SERVICE_USER="${SERVICE_USER:-onevoice}"
+SERVICE_HOME="/home/${SERVICE_USER}"
+NC="${NEXTCLOUD_PATH:-/var/www/nextcloud}"
+DB_MODE="${DB_MODE:-local}"
+DB_HOST="${DB_HOST:-127.0.0.1}"
+DB_NAME="${DB_NAME:-nextcloud}"
+DB_USER="${DB_USER:-nextcloud}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+OBJECT_STORE="${OBJECT_STORE:-local}"
+NEXTCLOUD_DATA_DIR="${NEXTCLOUD_DATA_DIR:-$NC/data}"
+ENABLE_REDIS="${ENABLE_REDIS:-true}"
+ENABLE_CRON_TIMER="${ENABLE_CRON_TIMER:-true}"
+ENABLE_MCP="${ENABLE_MCP:-true}"
+ENABLE_CLOUDFLARED="${ENABLE_CLOUDFLARED:-true}"
+ENABLE_MAINTENANCE_TIMER="${ENABLE_MAINTENANCE_TIMER:-false}"
+ENABLE_MIGRATION_MOUNT="${ENABLE_MIGRATION_MOUNT:-false}"
+CREATE_SEED_USERS="${CREATE_SEED_USERS:-true}"
+THEME_NAME="${THEME_NAME:-OneVoice}"
+THEME_PRIMARY_COLOR="${THEME_PRIMARY_COLOR:-#1a5d3a}"
+LOGO_SRC="${LOGO_SRC:-$SCRIPT_DIR/../terraform/assets/logo.png}"
+PASSWORD_FILE="/root/onevoice-user-passwords.txt"
+
+log()  { echo -e "\n==> $*"; }
+die()  { echo "ERROR: $*" >&2; exit 1; }
+
+require() {
+  local name="$1"
+  [[ -n "${!name:-}" ]] || die "$name is required in $ENV_FILE"
+}
+
+# Full `if` blocks rather than `[[ cond ]] && require ...`. The one-liner form
+# would not abort here (under `set -e` bash exempts a failed non-final element
+# of an AND-list), but it does leave the list evaluating to 1, which turns into
+# a bogus failure exit if such a line ever ends up last in a script or function.
+require ADMIN_PASSWORD
+require DB_PASSWORD
+
+# DOMAIN_NAME is optional. The EC2 build always had one because the tunnel was
+# the only way in; here the instance can legitimately run on a bare IP before
+# any DNS or tunnel exists, so require only that SOMETHING addresses the box.
+if [[ -z "${SERVER_IP:-}" && -z "${DOMAIN_NAME:-}" ]]; then
+  die "Set SERVER_IP, DOMAIN_NAME, or both in $ENV_FILE — Nextcloud needs at
+least one trusted domain or every request is rejected as untrusted."
+fi
+
+if [[ "$DB_MODE" == "local" ]]; then
+  require DB_ROOT_PASSWORD
+fi
+if [[ "$ENABLE_CLOUDFLARED" == "true" ]]; then
+  require CLOUDFLARE_TUNNEL_TOKEN
+  require DOMAIN_NAME
+fi
+
+# How Nextcloud will actually be reached. This drives trusted_proxies,
+# overwriteprotocol and overwrite.cli.url, which MUST agree with reality:
+# telling Nextcloud it is behind an HTTPS proxy while it is really serving
+# plain HTTP on a raw IP produces redirect loops and assets that never load.
+if [[ "$ENABLE_CLOUDFLARED" == "true" && -n "${DOMAIN_NAME:-}" ]]; then
+  BEHIND_TLS_PROXY="true"
+  BASE_URL="https://${DOMAIN_NAME}"
+else
+  BEHIND_TLS_PROXY="false"
+  BASE_URL="http://${SERVER_IP}"
+fi
+if [[ "$ENABLE_MAINTENANCE_TIMER" == "true" ]]; then
+  require GITHUB_PAT
+fi
+
+# ---------------------------------------------------------------------------
+# Safety guards — the two ways this clone can damage prod
+# ---------------------------------------------------------------------------
+if [[ "$OBJECT_STORE" == "s3" ]]; then
+  require S3_BUCKET
+  require S3_ACCESS_KEY
+  require S3_SECRET_KEY
+
+  # A primary object store keys objects as urn:oid:<fileid>, where fileid is a
+  # row id in this instance's own database. This clone's database is empty, so
+  # it will start allocating fileid 1, 2, 3... and overwrite prod's objects
+  # one by one. There is no recovery short of S3 version rollback.
+  if [[ "$S3_BUCKET" == *"prod"* && "${I_UNDERSTAND_SHARED_BUCKET:-}" != "yes" ]]; then
+    die "S3_BUCKET '$S3_BUCKET' looks like a production bucket.
+
+A second Nextcloud with a fresh database WILL overwrite objects in a bucket
+that is already serving as another instance's primary object store, because
+object keys (urn:oid:<fileid>) are derived from database row ids that both
+instances allocate from 1.
+
+Create a new, empty bucket for this clone. If you have genuinely verified the
+bucket is unused, set I_UNDERSTAND_SHARED_BUCKET=yes."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Cloudflare Tunnel
+# ---------------------------------------------------------------------------
+if [[ "$ENABLE_CLOUDFLARED" == "true" ]]; then
+  log "Configuring cloudflared"
+
+  # A tunnel token identifies a TUNNEL, not a machine. If this token is the
+  # prod one, cloudflared registers this VPS as an additional replica and
+  # Cloudflare load-balances onevoice.knoch.dev across both boxes.
+  if [[ -f /etc/cloudflared/token ]] && \
+     ! cmp -s <(printf '%s' "$CLOUDFLARE_TUNNEL_TOKEN") /etc/cloudflared/token; then
+    echo "NOTE: replacing existing tunnel token."
+  fi
+
+  mkdir -p /etc/cloudflared
+  printf '%s' "$CLOUDFLARE_TUNNEL_TOKEN" > /etc/cloudflared/token
+  chmod 600 /etc/cloudflared/token
+  systemctl enable --now cloudflared
+fi
+
+# ---------------------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------------------
+if [[ "$DB_MODE" == "local" ]]; then
+  log "Preparing local MariaDB database"
+
+  # mariadb-server installs with a passwordless unix-socket root on EL. Set a
+  # root password on first run only, then use it from here on.
+  if mariadb -u root --protocol=socket -e "SELECT 1" &>/dev/null; then
+    # `DROP USER IF EXISTS`, not `DELETE FROM mysql.user`: since MariaDB 10.4
+    # mysql.user is a non-updatable VIEW over mysql.global_priv, so the DELETE
+    # fails with "target table is not updatable", the client exits non-zero,
+    # and `set -e` kills the whole run before Nextcloud is ever installed.
+    mariadb -u root --protocol=socket <<EOF
+ALTER USER 'root'@'localhost' IDENTIFIED BY '${DB_ROOT_PASSWORD}';
+DROP USER IF EXISTS ''@'localhost';
+DROP USER IF EXISTS ''@'$(hostname)';
+DROP DATABASE IF EXISTS test;
+FLUSH PRIVILEGES;
+EOF
+  fi
+
+  # utf8mb4 at creation time — retrofitting a latin1/utf8 database later means
+  # occ db:convert-mysql-charset against live data.
+  mariadb -u root -p"${DB_ROOT_PASSWORD}" <<EOF
+CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\`
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE USER IF NOT EXISTS '${DB_USER}'@'localhost' IDENTIFIED BY '${DB_PASSWORD}';
+ALTER USER '${DB_USER}'@'localhost' IDENTIFIED BY '${DB_PASSWORD}';
+GRANT ALL PRIVILEGES ON \`${DB_NAME}\`.* TO '${DB_USER}'@'localhost';
+FLUSH PRIVILEGES;
+EOF
+fi
+
+# ---------------------------------------------------------------------------
+# Web stack up
+# ---------------------------------------------------------------------------
+log "Starting php-fpm and nginx"
+systemctl restart php-fpm
+systemctl restart nginx
+
+# ---------------------------------------------------------------------------
+# occ helper
+# ---------------------------------------------------------------------------
+occ() { sudo -u nginx php "$NC/occ" "$@"; }
+
+# ---------------------------------------------------------------------------
+# Nextcloud install
+# ---------------------------------------------------------------------------
+if [[ ! -f "$NC/config/config.php" ]]; then
+  log "Running Nextcloud installer"
+
+  INSTALL_DATA_DIR="$NEXTCLOUD_DATA_DIR"
+  if [[ "$OBJECT_STORE" == "s3" ]]; then
+    # Still required even with an object store — Nextcloud keeps its log,
+    # appdata and temp files on local disk.
+    INSTALL_DATA_DIR="$NC/data"
+    mkdir -p "$INSTALL_DATA_DIR"
+    chown nginx:nginx "$INSTALL_DATA_DIR"
+    chmod 770 "$INSTALL_DATA_DIR"
+  fi
+
+  occ maintenance:install \
+    --database "mysql" \
+    --database-host "$DB_HOST" \
+    --database-name "$DB_NAME" \
+    --database-user "$DB_USER" \
+    --database-pass "$DB_PASSWORD" \
+    --admin-user "$ADMIN_USER" \
+    --admin-pass "$ADMIN_PASSWORD" \
+    --data-dir "$INSTALL_DATA_DIR"
+
+  # 4-byte UTF-8 (emoji in filenames). Harmless if the DB is already utf8mb4.
+  occ config:system:set mysql.utf8mb4 --value true --type boolean
+  occ maintenance:repair --include-expensive || true
+
+  if [[ "$OBJECT_STORE" == "s3" ]]; then
+    log "Configuring S3 primary object store"
+
+    # class must be a sub-key, not the top-level value, or Nextcloud throws
+    # "No class given for objectstore"
+    occ config:system:set objectstore class --value "OC\\Files\\ObjectStore\\S3"
+    occ config:system:set objectstore arguments bucket --value "$S3_BUCKET"
+    occ config:system:set objectstore arguments region --value "$S3_REGION"
+    occ config:system:set objectstore arguments use_path_style \
+      --value "${S3_USE_PATH_STYLE:-false}" --type boolean
+    occ config:system:set objectstore arguments use_ssl \
+      --value "${S3_USE_SSL:-true}" --type boolean
+
+    # THE key difference from the EC2 deployment. On EC2 the credentials were
+    # deliberately omitted so the AWS SDK would pick up the instance profile
+    # from IMDS. There is no IMDS and no instance profile on a Bluehost VPS,
+    # so an explicit IAM user access key is mandatory here.
+    occ config:system:set objectstore arguments key    --value "$S3_ACCESS_KEY"
+    occ config:system:set objectstore arguments secret --value "$S3_SECRET_KEY"
+
+    # Non-AWS S3 endpoints (B2/Wasabi/MinIO) need an explicit hostname.
+    if [[ -n "${S3_HOSTNAME:-}" ]]; then
+      occ config:system:set objectstore arguments hostname --value "$S3_HOSTNAME"
+    fi
+  fi
+
+  # deletes on S3 storage crash Trashbin's move-to-trash handoff (upstream bug,
+  # #28) — disabled instance-wide, no undo/trash as a trade-off.
+  # Only relevant when S3 is the primary store; on local disk trash works fine,
+  # so the clone keeps it unless it is actually running on S3.
+  if [[ "$OBJECT_STORE" == "s3" ]]; then
+    occ app:disable files_trashbin
+  fi
+
+  log "Nextcloud install complete."
+else
+  log "Nextcloud already configured, skipping install."
+fi
+
+# ---------------------------------------------------------------------------
+# Trusted domains / proxies  (re-applied every run, unlike the original)
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Migration bucket as external storage
+# ---------------------------------------------------------------------------
+# Deliberately OUTSIDE the install-only block above. In the EC2 script this
+# lived inside it, so once config.php existed the mount could never be created
+# or corrected by re-running — and getting an S3-compatible endpoint right on
+# the first attempt is exactly the thing that needs a second pass.
+if [[ "$ENABLE_MIGRATION_MOUNT" == "true" ]]; then
+  require MIGRATION_BUCKET
+  require MIGRATION_ACCESS_KEY_ID
+  require MIGRATION_SECRET_ACCESS_KEY
+
+  log "Configuring migration bucket as external storage"
+
+  # files_external ships with Nextcloud but isn't enabled by default
+  occ app:enable files_external
+
+  # The EC2 script hardcoded s3.<region>.amazonaws.com. Backblaze B2, Wasabi
+  # and MinIO all speak the same S3 API on a different endpoint, so the host
+  # is configurable; leaving MIGRATION_HOSTNAME blank keeps the AWS default.
+  MIGRATION_HOST="${MIGRATION_HOSTNAME:-s3.${MIGRATION_REGION:-us-east-1}.amazonaws.com}"
+  MOUNT_NAME="${MIGRATION_MOUNT_NAME:-Migration}"
+  echo "    endpoint: ${MIGRATION_HOST}  bucket: ${MIGRATION_BUCKET}"
+  echo "    mount name: ${MOUNT_NAME}"
+
+  # Reuse an existing "Migration" mount rather than stacking up duplicates on
+  # every run. files_external:list is tabular, so pull the id off the row.
+  MOUNT_ID="$(occ files_external:list --output=json 2>/dev/null \
+    | grep -o '"mount_id":[0-9]*' | head -1 | grep -oE '[0-9]+' || true)"
+
+  if [[ -n "$MOUNT_ID" ]]; then
+    echo "    updating existing mount id ${MOUNT_ID}"
+    occ files_external:option "$MOUNT_ID" bucket         "$MIGRATION_BUCKET"
+    occ files_external:option "$MOUNT_ID" hostname       "$MIGRATION_HOST"
+    occ files_external:option "$MOUNT_ID" region         "${MIGRATION_REGION:-us-east-1}"
+    occ files_external:option "$MOUNT_ID" key            "$MIGRATION_ACCESS_KEY_ID"
+    occ files_external:option "$MOUNT_ID" secret         "$MIGRATION_SECRET_ACCESS_KEY"
+    occ files_external:option "$MOUNT_ID" use_ssl        "${MIGRATION_USE_SSL:-true}"
+    occ files_external:option "$MOUNT_ID" use_path_style "${MIGRATION_USE_PATH_STYLE:-false}"
+  else
+    # The `amazons3` backend id is the S3 backend generally, not AWS
+    # specifically — it is the correct one for any S3-compatible provider.
+    #
+    # No --user flag, so this is a SYSTEM mount: visible to every user, which
+    # is what you want when the bucket is the instance's real storage rather
+    # than one person's staging area.
+    CREATE_OUT="$(occ files_external:create \
+      "$MOUNT_NAME" amazons3 amazons3::accesskey \
+      --config bucket="$MIGRATION_BUCKET" \
+      --config hostname="$MIGRATION_HOST" \
+      --config region="${MIGRATION_REGION:-us-east-1}" \
+      --config use_ssl="${MIGRATION_USE_SSL:-true}" \
+      --config use_path_style="${MIGRATION_USE_PATH_STYLE:-false}" \
+      --config key="$MIGRATION_ACCESS_KEY_ID" \
+      --config secret="$MIGRATION_SECRET_ACCESS_KEY")"
+    echo "$CREATE_OUT"
+    # Read the id back rather than assuming 1 — it is only 1 on a virgin
+    # instance with no other external mounts.
+    MOUNT_ID="$(grep -oE '[0-9]+' <<<"$CREATE_OUT" | tail -1)"
+  fi
+
+  # Verify now, so a bad bucket or key surfaces here instead of as a mount that
+  # silently shows up empty in the UI.
+  MIGRATION_VERIFIED="false"
+  # Capture first — piping into `grep -q` under pipefail can report failure on
+  # a successful match (SIGPIPE race), which here would mean a scary false
+  # "mount did not verify" warning on a mount that is actually fine.
+  VERIFY_OUT="$(occ files_external:verify "$MOUNT_ID" 2>&1 || true)"
+  echo "$VERIFY_OUT" | sed 's/^/    /'
+  if [[ -n "$MOUNT_ID" ]] && ! grep -q 'status: ok' <<<"$VERIFY_OUT"; then
+    echo "
+WARNING: the Migration mount did not verify.
+  Confirm MIGRATION_BUCKET is the bucket NAME (the S3 endpoint 404s on a
+  Backblaze bucket ID), that the key has access to it, and that
+  MIGRATION_REGION matches the endpoint host.
+  Nextcloud itself is installed and usable. Fix the env file and re-run this
+  script, or inspect with:
+    sudo -u nginx php $NC/occ files_external:list
+    sudo -u nginx php $NC/occ files_external:verify $MOUNT_ID"
+  else
+    MIGRATION_VERIFIED="true"
+    echo "    mount verified OK"
+  fi
+fi
+
+log "Setting trusted domains and proxy trust"
+
+# The EC2 script wrote indices 1 and 2 on top of whatever the installer left at
+# index 0 (usually "localhost"), so the array only ever grew and you could not
+# express "this IP and nothing else". Delete and rewrite instead: the list ends
+# up exactly what the env file asks for, and re-running never accumulates
+# stale entries.
+TRUSTED_DOMAINS=()
+if [[ -n "${SERVER_IP:-}" ]];   then TRUSTED_DOMAINS+=("$SERVER_IP");   fi
+if [[ -n "${DOMAIN_NAME:-}" ]]; then TRUSTED_DOMAINS+=("$DOMAIN_NAME"); fi
+
+# `|| true`: deleting a key that was never set is a no-op we do not want to
+# abort on, and trusted_domains is absent on a brand new install.
+occ config:system:delete trusted_domains || true
+for i in "${!TRUSTED_DOMAINS[@]}"; do
+  occ config:system:set trusted_domains "$i" --value "${TRUSTED_DOMAINS[$i]}"
+  echo "    trusted_domains[$i] = ${TRUSTED_DOMAINS[$i]}"
+done
+
+occ config:system:set overwrite.cli.url --value "$BASE_URL"
+
+if [[ "$BEHIND_TLS_PROXY" == "true" ]]; then
+  # Nextcloud sits behind Cloudflare Tunnel (HTTPS at the edge, plain HTTP
+  # locally) — without trusting that, protocol detection is inconsistent
+  # between requests and corrupts session cookie encryption ("HMAC does not
+  # match", spinning logins, getting bounced back to the login screen).
+  occ config:system:set trusted_proxies 0 --value "127.0.0.1"
+  occ config:system:set overwriteprotocol --value "https"
+else
+  # Reached directly over plain HTTP on the raw IP. Forcing overwriteprotocol
+  # to https here would make Nextcloud emit https:// URLs that nothing is
+  # listening on — infinite redirects and missing CSS. Clear both so they do
+  # not linger from an earlier tunnel-enabled run.
+  occ config:system:delete overwriteprotocol || true
+  occ config:system:delete trusted_proxies   || true
+  echo "    plain HTTP on ${BASE_URL} — proxy overrides cleared"
+fi
+
+# ---------------------------------------------------------------------------
+# Redis  (addition — see README "Deliberate differences")
+# ---------------------------------------------------------------------------
+# On AlmaLinux 10 the server is Valkey, not Redis — EL10 dropped redis after
+# its 7.4 license change. Valkey is wire-compatible, so the PHP extension and
+# Nextcloud's \OC\Memcache\Redis backend are unchanged; only the package and
+# unit names differ.
+#
+# Both checks matter. memcache.locking pointing at a cache server that is not
+# actually listening fails EVERY request, so an instance that would merely have
+# been slower without caching becomes completely unreachable. Verify the
+# extension AND the socket before committing the config.
+if [[ "$ENABLE_REDIS" == "true" ]]; then
+  # Capture then match on a here-string. `php -m | grep -qx` under pipefail is
+  # the same racy SIGPIPE pattern that made valkey detection flaky.
+  PHP_MODULES="$(php -m 2>/dev/null || true)"
+  if ! grep -qx redis <<<"$PHP_MODULES"; then
+    echo "NOTE: ENABLE_REDIS=true but the PHP redis extension is not loaded; skipping cache config."
+  elif ! timeout 3 bash -c 'echo > /dev/tcp/127.0.0.1/6379' 2>/dev/null; then
+    echo "NOTE: nothing is listening on 127.0.0.1:6379 (valkey/redis not running);
+      skipping cache config rather than pointing file locking at a dead server.
+      Check with: systemctl status valkey"
+  else
+    log "Configuring Valkey/Redis for local cache and file locking"
+    occ config:system:set redis host --value "127.0.0.1"
+    occ config:system:set redis port --value 6379 --type integer
+    occ config:system:set memcache.local   --value "\\OC\\Memcache\\Redis"
+    occ config:system:set memcache.locking --value "\\OC\\Memcache\\Redis"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Background jobs  (addition — see README "Deliberate differences")
+# ---------------------------------------------------------------------------
+if [[ "$ENABLE_CRON_TIMER" == "true" ]]; then
+  log "Switching background jobs to cron mode"
+  occ background:cron
+  systemctl enable --now nextcloud-cron.timer
+fi
+
+# ---------------------------------------------------------------------------
+# Theming
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Local-disk containment
+# ---------------------------------------------------------------------------
+# External storage does NOT keep Nextcloud off the local volume. Previews for
+# files on the B2 mount are generated and cached in the LOCAL data directory
+# (data/appdata_<instanceid>/preview), and on a bucket with many images that
+# is the single largest consumer of the VPS's 50 GB.
+#
+# Bound it: cap preview dimensions, skip previewing very large files, and keep
+# the provider list to cheap formats. Video previews in particular are
+# expensive in both CPU and disk and are off by default here.
+log "Bounding local disk usage (previews, logs)"
+
+occ config:system:set preview_max_x --value "${PREVIEW_MAX_PX:-2048}" --type integer
+occ config:system:set preview_max_y --value "${PREVIEW_MAX_PX:-2048}" --type integer
+occ config:system:set preview_max_filesize_image \
+  --value "${PREVIEW_MAX_FILESIZE_MB:-50}" --type integer
+occ config:app:set preview jpeg_quality --value "${PREVIEW_JPEG_QUALITY:-80}"
+
+# nextcloud.log also lives on local disk and grows without bound by default.
+occ config:system:set log_rotate_size \
+  --value "${LOG_ROTATE_BYTES:-104857600}" --type integer
+
+log "Applying OneVoice theming"
+LOGO_PATH="$NC/branding/logo.png"
+mkdir -p "$NC/branding"
+
+# The EC2 build pulled this with `aws s3 cp s3://<bucket>/branding/logo.png`,
+# which needed the instance profile. Out here the file ships with the repo.
+if [[ -f "$LOGO_SRC" ]]; then
+  install -o nginx -g nginx -m 0644 "$LOGO_SRC" "$LOGO_PATH"
+  occ theming:config logo "$LOGO_PATH"
+else
+  echo "NOTE: logo not found at $LOGO_SRC; skipping logo, keeping name/colour."
+fi
+
+occ theming:config name "$THEME_NAME"
+occ theming:config primary_color "$THEME_PRIMARY_COLOR"
+
+# ---------------------------------------------------------------------------
+# MCP server
+# ---------------------------------------------------------------------------
+if [[ "$ENABLE_MCP" == "true" ]]; then
+  log "Configuring nextcloud-mcp-server"
+  require MCP_USERNAME
+  require MCP_APP_PASSWORD
+
+  # BASE_URL, not a hardcoded https://$DOMAIN_NAME — on an IP-only instance
+  # that would point the MCP server at an HTTPS endpoint that does not exist.
+  cat > "${SERVICE_HOME}/nextcloud-mcp-server/.env" <<EOF
+NEXTCLOUD_HOST=${BASE_URL}
+NEXTCLOUD_USERNAME=${MCP_USERNAME}
+NEXTCLOUD_PASSWORD=${MCP_APP_PASSWORD}
+EOF
+  chown "${SERVICE_USER}:${SERVICE_USER}" "${SERVICE_HOME}/nextcloud-mcp-server/.env"
+  chmod 600 "${SERVICE_HOME}/nextcloud-mcp-server/.env"
+  systemctl enable --now nextcloud-mcp
+fi
+
+# ---------------------------------------------------------------------------
+# Maintenance automation
+# ---------------------------------------------------------------------------
+if [[ "$ENABLE_MAINTENANCE_TIMER" == "true" ]]; then
+  log "Configuring maintenance automation"
+  sudo -u "$SERVICE_USER" bash -c "echo '${GITHUB_PAT}' | gh auth login --with-token"
+  sudo -u "$SERVICE_USER" gh auth setup-git
+  systemctl enable --now nextcloud-maintenance.timer
+else
+  log "Maintenance timer disabled (the EC2 host already runs it)"
+fi
+
+# ---------------------------------------------------------------------------
+# Seed users
+# ---------------------------------------------------------------------------
+if [[ "$CREATE_SEED_USERS" == "true" ]]; then
+  log "Creating seed users"
+
+  declare -A NEW_USERS=(
+    ["jsomori"]="Joseph Somori"
+    ["eayanwale"]="Enoch Ayanwale"
+    ["dcole"]="Dionne Cole"
+    ["dsomori"]="Deborah Somori"
+    ["nakinsanmi"]="Naomi Akinsanmi"
+    ["aakinsanmi"]="Ayomide Akinsanmi"
+    ["fbajere"]="Feyisola Bajere"
+    ["gawogbade"]="Goodness Awogbade"
+    ["famure"]="Fiyin Amure"
+    ["fojo"]="Favor Ojo"
+  )
+
+  touch "$PASSWORD_FILE"
+  chmod 600 "$PASSWORD_FILE"
+  chown root:root "$PASSWORD_FILE"
+
+  EXISTING_USERS="$(occ user:list --output=json)"
+
+  for USERNAME in "${!NEW_USERS[@]}"; do
+    DISPLAY_NAME="${NEW_USERS[$USERNAME]}"
+
+    if grep -q "\"${USERNAME}\":" <<<"$EXISTING_USERS"; then
+      echo "User $USERNAME already exists, skipping."
+      continue
+    fi
+
+    GENERATED_PASSWORD="$(openssl rand -base64 18)"
+
+    sudo -u nginx OC_PASS="$GENERATED_PASSWORD" php "$NC/occ" user:add \
+      --password-from-env \
+      --display-name="$DISPLAY_NAME" \
+      "$USERNAME"
+
+    # Replaces `aws ssm put-parameter --type SecureString`. There is no SSM
+    # out here; root-only file on the box instead.
+    printf '%s\t%s\t%s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$USERNAME" "$GENERATED_PASSWORD" \
+      >> "$PASSWORD_FILE"
+
+    echo "Created user $USERNAME, password recorded in $PASSWORD_FILE"
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# External storage scan — LAST, and off by default
+# ---------------------------------------------------------------------------
+# `files:scan --all` walks every object in the bucket over the S3 API and
+# writes an oc_filecache row per file. On a bucket with real data that is hours,
+# not minutes. It runs last so it can never delay the rest of the configuration,
+# and it is opt-in because external storage does NOT require it — Nextcloud
+# scans those mounts lazily when a user browses them. Pre-populating the cache
+# only makes the first browse and search faster.
+if [[ "${SCAN_EXTERNAL_ON_SETUP:-false}" == "true" && "${MIGRATION_VERIFIED:-false}" == "true" ]]; then
+  log "Scanning external storage (this can take a long time)"
+  occ files:scan --all
+elif [[ "${MIGRATION_VERIFIED:-false}" == "true" ]]; then
+  log "Skipping external storage scan (SCAN_EXTERNAL_ON_SETUP=false)"
+  echo "    The mount works and its files appear when browsed. To pre-populate"
+  echo "    the file cache in the background later:"
+  echo "      sudo -u nginx nohup php $NC/occ files:scan --all >/var/log/nc-scan.log 2>&1 &"
+fi
+
+log "Post-install status"
+occ status
+occ config:system:get trusted_domains
+
+cat <<EOF
+
+Nextcloud configuration complete.
+
+  URL          ${BASE_URL}
+  Trusted      ${TRUSTED_DOMAINS[*]}
+  Admin user   ${ADMIN_USER}
+  Object store ${OBJECT_STORE}
+  Database     ${DB_MODE} (${DB_HOST}/${DB_NAME})
+  Seed user passwords: ${PASSWORD_FILE}
+
+Check for remaining warnings in Administration settings > Overview, or:
+  sudo -u nginx php ${NC}/occ setupchecks
+EOF

--- a/onevoice-storage/bluehost/files/camerarawpreviews-register-viewer.js
+++ b/onevoice-storage/bluehost/files/camerarawpreviews-register-viewer.js
@@ -1,0 +1,65 @@
+/**
+ * Replacement for camerarawpreviews/js/register-viewer.js
+ *
+ * The stock file registers its Viewer handler inside a bare
+ *   if (OCA.Viewer && typeof OCA.Viewer.registerHandler === 'function') { ... }
+ * guard, and is loaded by Util::addInitScript as a DEFERRED CLASSIC script.
+ * The Viewer app's own bundle is an ES MODULE loaded later in the document.
+ * Deferred classic scripts and module scripts execute in document order, so
+ * this file runs ~19 scripts before OCA.Viewer exists — the guard is always
+ * false, the handler is never registered, and clicking a RAW file falls
+ * through to a plain download instead of opening the viewer.
+ *
+ * Fix: poll until OCA.Viewer appears, then register. The registration logic
+ * below is identical to the patch running on the EC2 instance since
+ * 2026-07-18 (this header comment is the only addition).
+ *
+ * NOTE: camerarawpreviews is a signed app, so replacing this file makes
+ * `occ integrity:check-app camerarawpreviews` report INVALID_HASH. That is
+ * expected and matches EC2. An app update overwrites this file and silently
+ * restores the broken behaviour — configure.sh re-applies it on every run.
+ */
+(function() {
+    function registerRawViewer() {
+        if (typeof OCA === "undefined" || !OCA.Viewer || typeof OCA.Viewer.registerHandler !== "function") {
+            return false;
+        }
+        OCA.Viewer.registerHandler({
+            id: "camerarawpreviews",
+            group: "media",
+            mimes: ["image/x-dcraw"],
+            component: {
+                name: "RAWViewer",
+                props: {
+                    fileid: { type: Number, default: null },
+                    filename: { type: String, default: null },
+                    basename: { type: String, default: null },
+                    source: { type: String, default: null },
+                    davPath: { type: String, default: null },
+                    mime: { type: String, default: null },
+                    permissions: { type: String, default: null },
+                },
+                template: "<img :src=\"previewUrl\" :alt=\"filename\" style=\"max-width:100%;max-height:100%;object-fit:contain;\" />",
+                computed: {
+                    previewUrl: function() {
+                        if (this.fileid) {
+                            return OC.generateUrl("/core/preview?fileId=" + this.fileid + "&x=4096&y=4096&a=true");
+                        }
+                        return this.davPath || "";
+                    }
+                }
+            }
+        });
+        console.log("CameraRAW Previews: registered with Viewer");
+        return true;
+    }
+    if (!registerRawViewer()) {
+        var attempts = 0;
+        var interval = setInterval(function() {
+            attempts++;
+            if (registerRawViewer() || attempts > 50) {
+                clearInterval(interval);
+            }
+        }, 200);
+    }
+})();

--- a/onevoice-storage/bluehost/files/cloudflared.service
+++ b/onevoice-storage/bluehost/files/cloudflared.service
@@ -1,0 +1,15 @@
+# /etc/systemd/system/cloudflared.service
+[Unit]
+Description=Cloudflare Tunnel client
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+TimeoutStartSec=15
+Type=notify
+ExecStart=/usr/bin/cloudflared --no-autoupdate tunnel run --token-file /etc/cloudflared/token
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/onevoice-storage/bluehost/files/nextcloud-cron.service
+++ b/onevoice-storage/bluehost/files/nextcloud-cron.service
@@ -1,0 +1,13 @@
+# /etc/systemd/system/nextcloud-cron.service
+#
+# No equivalent in the AMI build, which left background jobs on AJAX — they
+# only fire when a browser loads a page, so file scans, share expiry, previews
+# and cleanup jobs stall on a quiet instance.
+[Unit]
+Description=Nextcloud background jobs
+
+[Service]
+Type=oneshot
+User=nginx
+ExecCondition=/usr/bin/php -f __NEXTCLOUD_PATH__/occ status -e
+ExecStart=/usr/bin/php -f __NEXTCLOUD_PATH__/cron.php

--- a/onevoice-storage/bluehost/files/nextcloud-cron.timer
+++ b/onevoice-storage/bluehost/files/nextcloud-cron.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Nextcloud background jobs every 5 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+Unit=nextcloud-cron.service
+
+[Install]
+WantedBy=timers.target

--- a/onevoice-storage/bluehost/files/nextcloud-maintenance-check.sh
+++ b/onevoice-storage/bluehost/files/nextcloud-maintenance-check.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+#
+# nextcloud-maintenance-check.sh — Bluehost variant.
+#
+# Refactor of onevoice-storage/packer/files/nextcloud-maintenance-check.sh.
+# Differences from the EC2 original:
+#
+#   - REPO / SNS_TOPIC_ARN / NC_PATH come from the environment (systemd
+#     EnvironmentFile=/etc/onevoice/onevoice.env) instead of being hardcoded.
+#   - SNS publishing is optional. There is no instance profile out here, so if
+#     no AWS credentials are configured the script logs instead of paging.
+#   - The "verify EC2 public IP is still current" item is replaced with the
+#     VPS's own address, and the Docker check is gated on docker existing.
+#   - Section header says which host produced it, so EC2 and Bluehost runs are
+#     distinguishable if both timers ever end up enabled.
+#
+set -uo pipefail
+
+NC_PATH="${NEXTCLOUD_PATH:-/var/www/nextcloud}"
+REPO="${MAINTENANCE_REPO:-eayanwale/onevoice-storage}"
+REPO_URL="https://github.com/${REPO}.git"
+SNS_TOPIC_ARN="${SNS_TOPIC_ARN:-}"
+SNS_REGION="${SNS_REGION:-us-east-1}"
+HOST_LABEL="${ENVIRONMENT:-bluehost}"
+LABEL="maintenance"
+DATE=$(date -u +%Y-%m-%d)
+MONTH_YEAR=$(date -u +"%B %Y")
+
+TEST_MODE=0
+if [ "${1:-}" = "--test" ]; then
+  TEST_MODE=1
+fi
+
+if [ "$TEST_MODE" = "1" ]; then
+  BRANCH="maintenance/${HOST_LABEL}-test-${DATE}-$(date -u +%H%M%S)"
+  TITLE="[TEST] Nextcloud maintenance checklist (${HOST_LABEL}) - ${MONTH_YEAR}"
+  SECTION_TITLE="## ${MONTH_YEAR} Nextcloud maintenance - ${HOST_LABEL} (TEST RUN, ${DATE})"
+  SUBJECT_PREFIX="[TEST] "
+else
+  BRANCH="maintenance/${HOST_LABEL}-${DATE}"
+  TITLE="Nextcloud maintenance checklist (${HOST_LABEL}) - ${MONTH_YEAR}"
+  SECTION_TITLE="## ${MONTH_YEAR} Nextcloud maintenance - ${HOST_LABEL} (automated check, ${DATE})"
+  SUBJECT_PREFIX=""
+fi
+
+WORKDIR=$(mktemp -d)
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+notify() {
+  local subject="$1"
+  local message="$2"
+
+  # EC2 had an instance profile granting sns:Publish. A Bluehost VPS has no
+  # ambient AWS identity, so this degrades to a log line unless credentials
+  # were placed on the box deliberately.
+  if [ -z "$SNS_TOPIC_ARN" ] || ! command -v aws >/dev/null 2>&1; then
+    echo "NOTIFY (no SNS configured): ${SUBJECT_PREFIX}${subject} - ${message}"
+    return 0
+  fi
+  aws sns publish --region "$SNS_REGION" --topic-arn "$SNS_TOPIC_ARN" \
+    --subject "${SUBJECT_PREFIX}${subject}" --message "$message" >/dev/null \
+    || echo "NOTIFY FAILED (sns publish): ${subject}"
+}
+
+fail() {
+  local step="$1"
+  echo "FAILED: $step"
+  notify "Nextcloud maintenance automation FAILED" "Step failed: ${step}. Host $(hostname), $(date -u +%Y-%m-%dT%H:%M:%SZ). Check the box directly - no PR was opened this run."
+  exit 1
+}
+
+echo "==> Gathering findings"
+
+CORE_VERSION=$(sudo -u nginx php "$NC_PATH/occ" status 2>&1 | grep -oP 'versionstring: \K.*' || echo "unknown")
+UPDATE_CHECK=$(sudo -u nginx php "$NC_PATH/occ" update:check 2>&1)
+
+DISK=$(df -h / | tail -1)
+DISK_PCT=$(echo "$DISK" | awk '{print $5}')
+DISK_AVAIL=$(echo "$DISK" | awk '{print $4}')
+
+MEM_LINE=$(free -h | awk '/^Mem:/')
+MEM_AVAIL=$(echo "$MEM_LINE" | awk '{print $7}')
+MEM_TOTAL=$(echo "$MEM_LINE" | awk '{print $2}')
+
+DNF_UPDATES=$(sudo dnf check-update 2>&1 | grep -E '^\S+\.(x86_64|noarch)' | wc -l || echo "0")
+
+RUNNING_KERNEL=$(uname -r)
+LATEST_INSTALLED_KERNEL=$(rpm -q kernel | sed 's/^kernel-//' | sort -V | tail -1)
+if [ "$RUNNING_KERNEL" = "$LATEST_INSTALLED_KERNEL" ]; then
+  REBOOT_LINE="No reboot needed (running kernel matches latest installed: ${RUNNING_KERNEL})"
+else
+  REBOOT_LINE="Reboot recommended: running ${RUNNING_KERNEL}, latest installed is ${LATEST_INSTALLED_KERNEL}"
+fi
+
+CRON_USER=$(crontab -l 2>&1)
+CRON_ROOT=$(sudo crontab -l 2>&1)
+if echo "$CRON_USER $CRON_ROOT" | grep -qi 'no crontab'; then
+  BACKUP_CRON_LINE="No cron-based backup job found (user or root crontab)"
+else
+  BACKUP_CRON_LINE="Cron entries present - review manually: user=[$CRON_USER] root=[$CRON_ROOT]"
+fi
+
+# Unlike the AMI, nothing here installs Docker; only look if it exists.
+if command -v docker >/dev/null 2>&1; then
+  EXITED_CONTAINERS=$(sudo docker ps -a --filter "status=exited" --format '{{.Names}} ({{.Image}})' 2>&1)
+else
+  EXITED_CONTAINERS=""
+fi
+
+# Bluehost VPS addresses are static, but the tunnel is what actually serves
+# traffic — report both so a silent tunnel failure is visible.
+PUBLIC_IP=$(curl -fsS --max-time 10 https://api.ipify.org 2>/dev/null || echo "unknown")
+if systemctl is-active --quiet cloudflared; then
+  TUNNEL_LINE="cloudflared active"
+else
+  TUNNEL_LINE="cloudflared NOT active - site is likely unreachable"
+fi
+
+echo "==> Building checklist section"
+
+cat > "$WORKDIR/section.md" <<EOF
+${SECTION_TITLE}
+
+- [ ] Host reachability: public IP ${PUBLIC_IP}, ${TUNNEL_LINE}
+- [ ] Update Nextcloud core: currently ${CORE_VERSION}. ${UPDATE_CHECK}
+- [ ] Check Nextcloud app updates in Admin > Apps > Updates (not reliably listable via occ CLI)
+- [ ] OS packages: ${DNF_UPDATES} package(s) with updates available per \`dnf check-update\`
+- [ ] Kernel/reboot: ${REBOOT_LINE}
+- [ ] Disk usage: ${DISK_PCT} used, ${DISK_AVAIL} available on /
+- [ ] Memory: ${MEM_AVAIL} available of ${MEM_TOTAL}
+- [ ] Backups: ${BACKUP_CRON_LINE}
+$(if [ -n "$EXITED_CONTAINERS" ]; then echo "- [ ] Investigate exited Docker container(s): ${EXITED_CONTAINERS}"; fi)
+
+_Generated automatically by nextcloud-maintenance-check.sh on $(hostname) at $(date -u +%Y-%m-%dT%H:%M:%SZ)._
+EOF
+
+echo "==> Ensuring label exists"
+gh label list --repo "$REPO" --json name --jq '.[].name' | grep -qx "$LABEL" || \
+  gh label create "$LABEL" --repo "$REPO" --color 0E8A16 --description "Nextcloud server maintenance checklist"
+
+echo "==> Creating tracking issue"
+ISSUE_URL=$(gh issue create \
+  --repo "$REPO" \
+  --title "$TITLE" \
+  --body "$(cat "$WORKDIR/section.md")" \
+  --label "$LABEL") || fail "gh issue create"
+ISSUE_NUM=$(basename "$ISSUE_URL")
+echo "==> Issue: $ISSUE_URL"
+
+echo "==> Cloning repo"
+git clone --quiet --depth 1 -b dev "$REPO_URL" "$WORKDIR/repo" || fail "git clone"
+cd "$WORKDIR/repo"
+git checkout -b "$BRANCH"
+
+mkdir -p systems
+touch systems/maintenance.md
+{ echo; cat "$WORKDIR/section.md"; } >> systems/maintenance.md
+
+git config user.name "Nextcloud Maintenance Bot"
+git config user.email "maintenance-bot@onevoice.local"
+git add systems/maintenance.md
+git commit --quiet -m "Add ${MONTH_YEAR} Nextcloud maintenance checklist - ${HOST_LABEL} (automated)"
+
+echo "==> Pushing branch"
+git push --quiet origin "$BRANCH" || fail "git push"
+
+echo "==> Opening PR"
+PR_URL=$(gh pr create \
+  --repo "$REPO" \
+  --base dev \
+  --head "$BRANCH" \
+  --title "$TITLE" \
+  --body "Closes #${ISSUE_NUM}
+
+Automated monthly Nextcloud maintenance check from the ${HOST_LABEL} host. Review findings below and complete the checklist in \`systems/maintenance.md\` as maintenance is performed." \
+  --assignee eayanwale \
+  --label "$LABEL") || fail "gh pr create"
+
+echo "==> Notifying"
+notify "Nextcloud maintenance checklist ready" "${TITLE} is ready: PR ${PR_URL} (tracking issue ${ISSUE_URL})"
+
+echo "==> Done: ${PR_URL}"

--- a/onevoice-storage/bluehost/files/nextcloud-maintenance.service
+++ b/onevoice-storage/bluehost/files/nextcloud-maintenance.service
@@ -1,0 +1,14 @@
+# /etc/systemd/system/nextcloud-maintenance.service
+[Unit]
+Description=Nextcloud monthly maintenance check and PR
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=__SERVICE_USER__
+EnvironmentFile=__ENV_FILE__
+Environment=NEXTCLOUD_PATH=__NEXTCLOUD_PATH__
+ExecStart=__SERVICE_HOME__/scripts/nextcloud-maintenance-check.sh
+StandardOutput=journal
+StandardError=journal

--- a/onevoice-storage/bluehost/files/nextcloud-maintenance.timer
+++ b/onevoice-storage/bluehost/files/nextcloud-maintenance.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run Nextcloud maintenance check monthly on the 15th
+
+[Timer]
+OnCalendar=*-*-15 13:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/onevoice-storage/bluehost/files/nextcloud-mcp.service
+++ b/onevoice-storage/bluehost/files/nextcloud-mcp.service
@@ -1,0 +1,19 @@
+# /etc/systemd/system/nextcloud-mcp.service
+#
+# __SERVICE_USER__ / __SERVICE_HOME__ are substituted by provision.sh. The AMI
+# version hardcoded ec2-user, which does not exist on AlmaLinux.
+[Unit]
+Description=Nextcloud MCP Server
+After=network.target
+
+[Service]
+Type=simple
+User=__SERVICE_USER__
+WorkingDirectory=__SERVICE_HOME__/nextcloud-mcp-server
+EnvironmentFile=__SERVICE_HOME__/nextcloud-mcp-server/.env
+ExecStart=__SERVICE_HOME__/.local/bin/uv run nextcloud-mcp-server run --log-level info
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/onevoice-storage/bluehost/files/rate-limit.conf
+++ b/onevoice-storage/bluehost/files/rate-limit.conf
@@ -1,0 +1,1 @@
+limit_req_zone $binary_remote_addr zone=nextcloud_limit:10m rate=10r/s;

--- a/onevoice-storage/bluehost/onevoice.env.example
+++ b/onevoice-storage/bluehost/onevoice.env.example
@@ -1,0 +1,206 @@
+# OneVoice Nextcloud — Bluehost VPS configuration
+#
+# Copy to /etc/onevoice/onevoice.env on the VPS, fill in, then:
+#   chown root:root /etc/onevoice/onevoice.env
+#   chmod 600       /etc/onevoice/onevoice.env
+#
+# This file replaces BOTH of the AWS-side secret mechanisms:
+#   - SSM Parameter Store (every `aws ssm get-parameter` in user-data.sh)
+#   - Terraform templatefile() vars (${db_host}, ${s3_bucket}, ${domain_name}, ...)
+#
+# Anything marked REQUIRED must be set or configure.sh aborts before touching
+# the system.
+
+# ---------------------------------------------------------------------------
+# Identity / naming  (mirrors terraform var.organization + var.environment)
+# ---------------------------------------------------------------------------
+ORGANIZATION="onevoice"
+ENVIRONMENT="bluehost"          # NOT "prod" — see the tunnel warning below
+
+# The system account that owns the MCP server + maintenance scripts.
+# This is the Bluehost stand-in for "ec2-user". Created by provision.sh.
+SERVICE_USER="onevoice"
+
+# ---------------------------------------------------------------------------
+# Nextcloud
+# ---------------------------------------------------------------------------
+NEXTCLOUD_VERSION="30.0.0"      # matches the AMI; bump deliberately, not automatically
+NEXTCLOUD_PATH="/var/www/nextcloud"
+
+ADMIN_USER="admin"
+ADMIN_PASSWORD=""               # REQUIRED
+
+# Public hostname served via Cloudflare Tunnel. Added to trusted_domains.
+# Optional — leave blank to run on the bare IP until DNS/tunnel exists.
+# REQUIRED when ENABLE_CLOUDFLARED=true.
+DOMAIN_NAME=""                  # e.g. bluehost.knoch.dev
+
+# Public IPv4 of the VPS. Added to trusted_domains.
+SERVER_IP=""
+
+# SERVER_IP and DOMAIN_NAME together form the COMPLETE trusted_domains list —
+# configure.sh deletes and rewrites the array, so whichever of these you set is
+# exactly what Nextcloud will accept. Set only SERVER_IP for IP-only access.
+#
+# These also decide how Nextcloud describes itself to browsers:
+#   tunnel + domain -> https://DOMAIN_NAME, trusted_proxies + overwriteprotocol set
+#   IP only         -> http://SERVER_IP,   both overrides CLEARED
+# Claiming HTTPS while serving plain HTTP causes redirect loops and dead CSS,
+# so do not hand-set overwriteprotocol.
+
+# ---------------------------------------------------------------------------
+# Database  (replaces RDS aws_db_instance.nextcloud-db)
+# ---------------------------------------------------------------------------
+# "local"  -> provision.sh installs MariaDB on this VPS and configure.sh
+#             creates the database + user. This is the Bluehost default.
+# "remote" -> point at an existing server (incl. your RDS box, if you open
+#             its security group to the VPS — see README, not recommended).
+DB_MODE="local"
+
+DB_HOST="127.0.0.1"
+DB_NAME="nextcloud"
+DB_USER="nextcloud"
+DB_PASSWORD=""                  # REQUIRED
+
+# Root password for the freshly installed local MariaDB. Only used when
+# DB_MODE=local, and only on the very first run.
+DB_ROOT_PASSWORD=""             # REQUIRED when DB_MODE=local
+
+# ---------------------------------------------------------------------------
+# Primary object storage
+# ---------------------------------------------------------------------------
+# "local" -> Nextcloud stores files on the VPS disk at NEXTCLOUD_DATA_DIR.
+#            Self-contained, cannot touch prod data. DEFAULT.
+# "s3"    -> Nextcloud uses S3 as its primary object store, exactly like the
+#            EC2 deployment — except there is no instance profile out here, so
+#            you must supply an access key/secret for an IAM user.
+#
+#  ############################################################
+#  #  READ THIS BEFORE SETTING OBJECT_STORE=s3                #
+#  ############################################################
+#  A Nextcloud primary object store keys every object as `urn:oid:<fileid>`,
+#  where <fileid> is a row id in ITS OWN database. Two Nextcloud instances
+#  with two different databases pointed at ONE bucket will both allocate
+#  fileid 1, 2, 3... and silently overwrite each other's objects.
+#
+#  This clone has a brand new database. Pointing it at
+#  onevoice-prod-nextcloud-bucket WILL corrupt prod file content.
+#
+#  Use a NEW, EMPTY bucket. configure.sh refuses the prod bucket name
+#  unless you also set I_UNDERSTAND_SHARED_BUCKET=yes, which you should not.
+#  ############################################################
+OBJECT_STORE="local"
+
+NEXTCLOUD_DATA_DIR="/var/www/nextcloud/data"   # used when OBJECT_STORE=local
+
+S3_BUCKET=""                    # REQUIRED when OBJECT_STORE=s3 — a NEW bucket
+S3_REGION="us-east-1"
+S3_ACCESS_KEY=""                # REQUIRED when OBJECT_STORE=s3
+S3_SECRET_KEY=""                # REQUIRED when OBJECT_STORE=s3
+S3_USE_PATH_STYLE="false"
+S3_USE_SSL="true"
+# Set only for non-AWS S3 (Backblaze B2, Wasabi, MinIO). Blank = real AWS.
+S3_HOSTNAME=""
+
+# ---------------------------------------------------------------------------
+# "Migration" external storage  (files_external, mirrors user-data.sh)
+# ---------------------------------------------------------------------------
+# Read-mostly bucket mounted into the UI. Safe to share with prod — external
+# storage addresses objects by real path, not by fileid, so it has none of the
+# collision problem described above.
+#
+# Works with any S3-compatible provider, not just AWS. The `amazons3` backend
+# id is the S3 backend generally. For Backblaze B2:
+#   MIGRATION_HOSTNAME="s3.us-east-005.backblazeb2.com"
+#   MIGRATION_REGION="us-east-005"          # must match the endpoint
+#   MIGRATION_ACCESS_KEY_ID=<B2 keyID>
+#   MIGRATION_SECRET_ACCESS_KEY=<B2 applicationKey>
+#
+# MIGRATION_BUCKET must be the bucket NAME, the human-readable one you chose at
+# creation. The B2 console also shows a 24-hex-character bucket ID
+# (e.g. f3dbc2d8047a262da4040313) — that is for B2's native API and returns 404
+# through the S3 endpoint.
+#
+# Use external storage rather than OBJECT_STORE="s3" whenever the bucket
+# ALREADY CONTAINS FILES. A primary object store keys objects urn:oid:<fileid>
+# from its own database and cannot see real paths, so pre-existing files become
+# permanently invisible to Nextcloud. One bucket cannot serve both roles.
+ENABLE_MIGRATION_MOUNT="false"
+MIGRATION_BUCKET=""
+MIGRATION_MOUNT_NAME="Migration"   # folder name shown in the Files UI
+MIGRATION_REGION="us-east-1"
+MIGRATION_HOSTNAME=""           # blank = s3.<region>.amazonaws.com
+MIGRATION_USE_SSL="true"
+MIGRATION_USE_PATH_STYLE="false"
+MIGRATION_ACCESS_KEY_ID=""
+MIGRATION_SECRET_ACCESS_KEY=""
+
+# ---------------------------------------------------------------------------
+# Cloudflare Tunnel
+# ---------------------------------------------------------------------------
+#  ############################################################
+#  #  USE A DIFFERENT TUNNEL TOKEN THAN PROD                  #
+#  ############################################################
+#  A tunnel token identifies a tunnel, not a machine. Reusing the prod token
+#  here registers this VPS as a SECOND replica of the prod tunnel, and
+#  Cloudflare will round-robin onevoice.knoch.dev between the EC2 box and this
+#  one. Users get randomly served whichever instance answers.
+#
+#  Create a new tunnel + new hostname in the Cloudflare dashboard.
+#  ############################################################
+CLOUDFLARE_TUNNEL_TOKEN=""      # REQUIRED unless ENABLE_CLOUDFLARED=false
+ENABLE_CLOUDFLARED="true"
+
+# ---------------------------------------------------------------------------
+# Nextcloud MCP server
+# ---------------------------------------------------------------------------
+ENABLE_MCP="true"
+MCP_USERNAME=""
+MCP_APP_PASSWORD=""
+
+# ---------------------------------------------------------------------------
+# Maintenance automation
+# ---------------------------------------------------------------------------
+# Default OFF for the clone. The EC2 box already runs this timer on the 15th;
+# enabling it here too means two hosts opening two near-identical issues and
+# PRs against eayanwale/onevoice-storage every month.
+ENABLE_MAINTENANCE_TIMER="false"
+GITHUB_PAT=""
+MAINTENANCE_REPO="eayanwale/onevoice-storage"
+
+# SNS alerting from the maintenance script. Needs AWS credentials on the box;
+# leave blank and the script logs instead of publishing.
+SNS_TOPIC_ARN=""
+SNS_REGION="us-east-1"
+
+# ---------------------------------------------------------------------------
+# Additions beyond EC2 parity — see README "Deliberate differences"
+# ---------------------------------------------------------------------------
+# Redis for distributed file locking + local cache. The EC2 build has neither,
+# so it falls back to DB-backed locking and no opcode-adjacent user cache.
+ENABLE_REDIS="true"
+
+# systemd timer running `occ cron.php` every 5 minutes and switching Nextcloud
+# to cron mode. The EC2 build leaves background jobs on AJAX, which only fire
+# when someone loads a page.
+ENABLE_CRON_TIMER="true"
+
+# Open port 80/tcp in firewalld. AlmaLinux runs firewalld by default; Amazon
+# Linux 2023 does not, which is why the EC2 scripts never mention it.
+# Cloudflare Tunnel is outbound-only and needs NO inbound port, so leave this
+# false unless you want to reach the box by raw IP for debugging.
+OPEN_HTTP_PORT="false"
+
+# ---------------------------------------------------------------------------
+# Seed users (mirrors the NEW_USERS map in user-data.sh)
+# ---------------------------------------------------------------------------
+# Generated passwords go to /root/onevoice-user-passwords.txt (0600) instead
+# of SSM SecureString parameters.
+CREATE_SEED_USERS="true"
+
+# Branding
+THEME_NAME="OneVoice"
+THEME_PRIMARY_COLOR="#1a5d3a"
+# Local path to the logo. The EC2 build pulls this from
+# s3://<bucket>/branding/logo.png; out here we ship the file with the repo.
+LOGO_SRC=""                     # default: ../terraform/assets/logo.png

--- a/onevoice-storage/bluehost/onevoice.env.example
+++ b/onevoice-storage/bluehost/onevoice.env.example
@@ -198,6 +198,91 @@ OPEN_HTTP_PORT="false"
 # of SSM SecureString parameters.
 CREATE_SEED_USERS="true"
 
+# ---------------------------------------------------------------------------
+# Monitoring: Prometheus + node_exporter + Grafana
+# ---------------------------------------------------------------------------
+# Roughly 500-700 MB resident for all three. provision.sh reserves for this in
+# its php-fpm sizing (see FPM_RESERVE_MB), so enabling it does not over-commit
+# the box — but do not enable it without that reservation in place.
+ENABLE_MONITORING="false"
+
+# EVERYTHING BINDS TO LOOPBACK. Prometheus has no authentication of any kind:
+# anyone who reaches :9090 can read every metric and query the whole TSDB.
+# Only Grafana is ever exposed, and only through the Cloudflare Tunnel.
+# Do not change these to 0.0.0.0.
+PROMETHEUS_BIND="127.0.0.1:9090"
+NODE_EXPORTER_BIND="127.0.0.1:9100"
+GRAFANA_BIND_ADDR="127.0.0.1"
+GRAFANA_PORT="3000"
+
+PROMETHEUS_RETENTION="15d"
+NODE_EXPORTER_VERSION="1.12.1"     # not packaged for EL10; upstream tarball
+
+# Public URL Grafana believes it is served at. Must match the Cloudflare Tunnel
+# public hostname or logins redirect to the wrong place.
+#
+#   own hostname:  GRAFANA_ROOT_URL="https://grafana.knoch.dev/"
+#                  GRAFANA_SERVE_FROM_SUBPATH="false"
+#   sub-path:      GRAFANA_ROOT_URL="https://cloud.knoch.dev/grafana/"
+#                  GRAFANA_SERVE_FROM_SUBPATH="true"
+#
+# NOTE on a name like grafana.cloud.knoch.dev: Cloudflare's free Universal SSL
+# covers knoch.dev and *.knoch.dev only — one level. A second-level name is NOT
+# covered and browsers get a certificate error; that needs Advanced Certificate
+# Manager. grafana.knoch.dev is covered for free.
+GRAFANA_ROOT_URL=""
+GRAFANA_SERVE_FROM_SUBPATH="false"
+
+# ---------------------------------------------------------------------------
+# Outbound email (SMTP relay)
+# ---------------------------------------------------------------------------
+# Without this Nextcloud cannot send password resets, share notifications or
+# activity mail — and it fails SILENTLY, with nothing in the UI to say why.
+#
+# Do NOT try to deliver directly on port 25. Even where the host leaves 25 open
+# (Bluehost does), you would be sending straight to recipient MX servers from a
+# shared-hosting IP with no matching PTR record, which Gmail and Outlook reject
+# or spam-folder. An authenticated relay inherits the relay's reputation.
+#
+# Amazon SES (us-east-1):
+#   SMTP_HOST="email-smtp.us-east-1.amazonaws.com"
+#   SMTP_USER / SMTP_PASSWORD are SES *SMTP credentials* — created under
+#   SES > SMTP settings. They are NOT your AWS access keys, and the password
+#   is shown once and cannot be recovered afterwards.
+#   SES starts in SANDBOX: until you request production access it only
+#   delivers to verified addresses, so password resets to real users fail.
+#
+# Google Workspace: SMTP_HOST="smtp.gmail.com", SMTP_USER is the full address,
+# SMTP_PASSWORD must be a 16-character App Password (requires 2FA).
+ENABLE_SMTP="false"
+SMTP_HOST=""
+SMTP_PORT="587"
+SMTP_SECURE="tls"                # "tls" for 587 (STARTTLS), "ssl" for 465
+SMTP_AUTH="true"
+SMTP_USER=""
+SMTP_PASSWORD=""
+
+# Nextcloud splits the From address in two: MAIL_FROM_ADDRESS is the LOCAL
+# PART ONLY. "noreply" + "knoch.dev" -> noreply@knoch.dev
+MAIL_FROM_ADDRESS="noreply"
+MAIL_DOMAIN=""
+
+# ---------------------------------------------------------------------------
+# Camera RAW support
+# ---------------------------------------------------------------------------
+# Aliases image/x-dcraw to "image" so the UI treats .arw/.cr2/.nef/.dng/.orf/
+# .raf as images at all. Nextcloud ships a mismatch here: the extension map
+# produces image/x-dcraw while the alias file only covers application/x-dcraw.
+FIX_RAW_MIMETYPE="true"
+
+# Patches camerarawpreviews' register-viewer.js (load-order race) and the
+# Viewer's mimetype array so clicking a RAW file OPENS it instead of
+# downloading. Requires the camerarawpreviews app. Makes
+# `occ integrity:check-app camerarawpreviews` report INVALID_HASH — expected,
+# and matches the EC2 instance. Re-applied on every run because an app update
+# reverts it. See configure.sh for the full explanation.
+FIX_RAW_VIEWER="true"
+
 # Branding
 THEME_NAME="OneVoice"
 THEME_PRIMARY_COLOR="#1a5d3a"

--- a/onevoice-storage/bluehost/provision.sh
+++ b/onevoice-storage/bluehost/provision.sh
@@ -57,8 +57,26 @@ INNODB_MB=$(( TOTAL_MB * 20 / 100 ))
 if [[ "$INNODB_MB" -lt 128 ]];  then INNODB_MB=128;  fi
 if [[ "$INNODB_MB" -gt 1024 ]]; then INNODB_MB=1024; fi
 
-# ~60 MB resident per Nextcloud php-fpm child, given ~40% of RAM to PHP.
-FPM_MAX_CHILDREN=$(( TOTAL_MB * 40 / 100 / 60 ))
+# php-fpm sizing. Budget what is LEFT after everything else, rather than a
+# flat percentage of total RAM — the percentage approach was fine while
+# Nextcloud had the box to itself, but it silently over-commits as soon as
+# anything else is co-hosted.
+#
+# Reserve = InnoDB buffer pool + headroom for the OS, nginx, Valkey,
+# cloudflared and (when enabled) Prometheus + Grafana + node_exporter, which
+# together run about 700 MB.
+#
+# 100 MB per child, not the 60 MB a naive estimate suggests: measured RSS on
+# this workload ranged 60-106 MB, and the number that matters for avoiding the
+# OOM killer is the peak, not the average.
+#
+# On 3907 MB with a 781 MB pool that yields 16 children — ample for a handful
+# of users, where 26 was a promise the box could not keep under load.
+FPM_RESERVE_MB="${FPM_RESERVE_MB:-$(( INNODB_MB + 1500 ))}"
+FPM_AVAIL_MB=$(( TOTAL_MB - FPM_RESERVE_MB ))
+if [[ "$FPM_AVAIL_MB" -lt 400 ]]; then FPM_AVAIL_MB=400; fi
+
+FPM_MAX_CHILDREN="${FPM_MAX_CHILDREN:-$(( FPM_AVAIL_MB / 100 ))}"
 if [[ "$FPM_MAX_CHILDREN" -lt 4 ]];  then FPM_MAX_CHILDREN=4;  fi
 if [[ "$FPM_MAX_CHILDREN" -gt 50 ]]; then FPM_MAX_CHILDREN=50; fi
 FPM_START=$(( FPM_MAX_CHILDREN / 4 ));      if [[ "$FPM_START" -lt 2 ]]; then FPM_START=2; fi
@@ -66,6 +84,8 @@ FPM_MIN_SPARE="$FPM_START"
 FPM_MAX_SPARE=$(( FPM_MAX_CHILDREN / 2 ));  if [[ "$FPM_MAX_SPARE" -lt 3 ]]; then FPM_MAX_SPARE=3; fi
 
 log "Detected ${TOTAL_MB} MB RAM -> InnoDB pool ${INNODB_MB}M, php-fpm max_children ${FPM_MAX_CHILDREN}"
+echo "    reserved for OS/DB/monitoring: ${FPM_RESERVE_MB} MB; php-fpm budget: ${FPM_AVAIL_MB} MB"
+echo "    worst-case php-fpm RSS: $(( FPM_MAX_CHILDREN * 100 )) MB"
 
 # The Bluehost image ships with ZERO swap. With no swap the OOM killer fires
 # immediately on any spike rather than degrading, and the processes it picks
@@ -620,12 +640,24 @@ firewall-offline-cmd --add-service=ssh >/dev/null 2>&1 || true
 systemctl enable --now firewalld
 firewall-cmd --permanent --add-service=ssh >/dev/null
 
+# Symmetric on purpose. An add-only rule makes the flag one-way: flipping it
+# back to false would silently leave 80/tcp open, so the box stays exposed
+# while the config claims otherwise.
 if [[ "$OPEN_HTTP_PORT" == "true" ]]; then
   log "Opening 80/tcp"
   firewall-cmd --permanent --add-service=http >/dev/null
 else
-  log "Leaving 80/tcp closed — Cloudflare Tunnel is outbound-only and needs no inbound port"
+  log "Closing 80/tcp — Cloudflare Tunnel is outbound-only and needs no inbound port"
+  firewall-cmd --permanent --remove-service=http >/dev/null 2>&1 || true
 fi
+
+# cockpit is enabled by default on AlmaLinux and publishes a root-capable web
+# console on 9090/tcp. Nothing here uses it, and 9090 is also Prometheus's
+# port — leaving it open is both an unnecessary attack surface and confusing.
+if [[ "${ALLOW_COCKPIT:-false}" != "true" ]]; then
+  firewall-cmd --permanent --remove-service=cockpit >/dev/null 2>&1 || true
+fi
+
 firewall-cmd --reload >/dev/null
 
 echo "    active services: $(firewall-cmd --list-services)"
@@ -638,6 +670,162 @@ if [[ "$ENABLE_CLOUDFLARED" == "true" ]]; then
   curl -fsSL https://pkg.cloudflare.com/cloudflared-ascii.repo -o /etc/yum.repos.d/cloudflared.repo
   dnf install -y cloudflared
   install -m 0644 "$SCRIPT_DIR/files/cloudflared.service" /etc/systemd/system/cloudflared.service
+fi
+
+# ---------------------------------------------------------------------------
+# Monitoring: Prometheus + node_exporter + Grafana
+# ---------------------------------------------------------------------------
+# Everything binds to LOOPBACK ONLY. Prometheus in particular ships with no
+# authentication whatsoever — anyone who can reach :9090 can read every metric
+# and run arbitrary queries against the whole TSDB. It is never exposed; only
+# Grafana is, and only through the Cloudflare Tunnel.
+#
+# Both packages default to 0.0.0.0, so the bind address is overridden before
+# either service is started for the first time, not after.
+if [[ "${ENABLE_MONITORING:-false}" == "true" ]]; then
+  log "Installing monitoring stack"
+
+  # prometheus is in EPEL, grafana in AppStream. grafana-selinux carries the
+  # policy module — required here, SELinux is enforcing.
+  dnf install -y prometheus grafana grafana-selinux
+
+  # --- node_exporter ---------------------------------------------------
+  # Not packaged for EL10 under any name, so it comes from the upstream
+  # release tarball, checksum-verified.
+  NE_VER="${NODE_EXPORTER_VERSION:-1.12.1}"
+  NE_BIND="${NODE_EXPORTER_BIND:-127.0.0.1:9100}"
+  if [[ -x /usr/local/bin/node_exporter ]] && \
+     /usr/local/bin/node_exporter --version 2>&1 | grep -q "$NE_VER"; then
+    log "node_exporter ${NE_VER} already installed"
+  else
+    log "Installing node_exporter ${NE_VER}"
+    NE_TGZ="node_exporter-${NE_VER}.linux-amd64.tar.gz"
+    cd /tmp
+    curl -fsSL -O "https://github.com/prometheus/node_exporter/releases/download/v${NE_VER}/${NE_TGZ}"
+    curl -fsSL -O "https://github.com/prometheus/node_exporter/releases/download/v${NE_VER}/sha256sums.txt"
+    grep " ${NE_TGZ}\$" sha256sums.txt | sha256sum -c -
+    tar xzf "$NE_TGZ"
+    install -m 0755 "node_exporter-${NE_VER}.linux-amd64/node_exporter" /usr/local/bin/node_exporter
+    rm -rf "$NE_TGZ" sha256sums.txt "node_exporter-${NE_VER}.linux-amd64"
+    # A binary dropped into /usr/local/bin inherits no useful SELinux type;
+    # relabel it so systemd can execute it under an enforcing policy.
+    restorecon -F /usr/local/bin/node_exporter 2>/dev/null || true
+  fi
+
+  id -u node_exporter &>/dev/null || \
+    useradd --system --no-create-home --shell /sbin/nologin node_exporter
+
+  cat > /etc/systemd/system/node_exporter.service <<EOF
+[Unit]
+Description=Prometheus Node Exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=node_exporter
+Group=node_exporter
+Type=simple
+ExecStart=/usr/local/bin/node_exporter --web.listen-address=${NE_BIND}
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+ProtectHome=yes
+ProtectSystem=strict
+PrivateTmp=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  # --- prometheus ------------------------------------------------------
+  # The unit is ExecStart=/usr/bin/prometheus \$ARGS with ARGS sourced from
+  # /etc/default/prometheus, so the listen address goes there.
+  PROM_BIND="${PROMETHEUS_BIND:-127.0.0.1:9090}"
+  cat > /etc/default/prometheus <<EOF
+# Managed by provision.sh — see onevoice.env for the knobs.
+# Loopback only: Prometheus has no authentication of any kind.
+ARGS='--config.file=/etc/prometheus/prometheus.yml \
+--storage.tsdb.path=/var/lib/prometheus/metrics2/ \
+--storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-15d} \
+--web.listen-address=${PROM_BIND} \
+--web.console.libraries=/etc/prometheus/console_libraries \
+--web.console.templates=/etc/prometheus/consoles'
+EOF
+
+  cat > /etc/prometheus/prometheus.yml <<EOF
+# Managed by provision.sh
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+  external_labels:
+    host: '$(hostname -s)'
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['${PROM_BIND}']
+
+  # Do NOT override the 'instance' label. Prometheus sets it to host:port by
+  # convention, and community dashboards rely on that shape — Node Exporter
+  # Full (ID 1860) splits it into \$node and \$port and matches
+  # instance=~"\$node:\$port". A friendly bare hostname there has no colon, so
+  # those queries match nothing and every panel renders N/A.
+  # Host identity travels in external_labels above instead.
+  - job_name: 'node'
+    static_configs:
+      - targets: ['${NE_BIND}']
+EOF
+  chown root:prometheus /etc/prometheus/prometheus.yml 2>/dev/null || true
+  chmod 0640 /etc/prometheus/prometheus.yml
+
+  # --- grafana ---------------------------------------------------------
+  # Ships with http_addr commented out, which means 0.0.0.0. Pin it.
+  GF_ADDR="${GRAFANA_BIND_ADDR:-127.0.0.1}"
+  GF_PORT="${GRAFANA_PORT:-3000}"
+  sed -i "s|^;\?http_addr =.*|http_addr = ${GF_ADDR}|" /etc/grafana/grafana.ini
+  sed -i "s|^;\?http_port =.*|http_port = ${GF_PORT}|" /etc/grafana/grafana.ini
+
+  if [[ -n "${GRAFANA_ROOT_URL:-}" ]]; then
+    sed -i "s|^;\?root_url =.*|root_url = ${GRAFANA_ROOT_URL}|" /etc/grafana/grafana.ini
+    sed -i "s|^;\?serve_from_sub_path =.*|serve_from_sub_path = ${GRAFANA_SERVE_FROM_SUBPATH:-false}|" \
+      /etc/grafana/grafana.ini
+  fi
+
+  # Point Grafana at the local Prometheus without anyone clicking through a
+  # setup wizard. Provisioned datasources are reconciled on every start.
+  install -d -o root -g grafana -m 0750 /etc/grafana/provisioning/datasources
+  cat > /etc/grafana/provisioning/datasources/prometheus.yml <<EOF
+# Managed by provision.sh
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://${PROM_BIND}
+    isDefault: true
+    editable: false
+EOF
+  chown root:grafana /etc/grafana/provisioning/datasources/prometheus.yml
+  chmod 0640 /etc/grafana/provisioning/datasources/prometheus.yml
+
+  # --- SELinux ---------------------------------------------------------
+  # grafana-selinux confines the server as grafana_t, which by default may
+  # not open an outbound TCP connection to Prometheus. The symptom is not a
+  # Grafana error but a datasource failure that reads like a network problem:
+  #
+  #   Status: 401. Message: Post "http://127.0.0.1:9090/api/v1/query":
+  #   dial tcp 127.0.0.1:9090: connect: permission denied
+  #
+  # ...and every dashboard panel renders N/A. Note `curl` as the grafana user
+  # succeeds, because that runs unconfined — only the service is confined, so
+  # testing by hand is misleading.
+  if command -v getsebool &>/dev/null && getsebool grafana_can_tcp_connect_prometheus_port &>/dev/null; then
+    setsebool -P grafana_can_tcp_connect_prometheus_port on
+    echo "    SELinux: grafana_can_tcp_connect_prometheus_port on"
+  fi
+
+  systemctl daemon-reload
+  log "Monitoring bound to loopback: prometheus ${PROM_BIND}, node_exporter ${NE_BIND}, grafana ${GF_ADDR}:${GF_PORT}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -748,6 +936,11 @@ if [[ "$ENABLE_MAINTENANCE_TIMER" == "true" ]]; then
 fi
 if [[ "$ENABLE_CRON_TIMER" == "true" ]]; then
   systemctl enable nextcloud-cron.timer
+fi
+if [[ "${ENABLE_MONITORING:-false}" == "true" ]]; then
+  systemctl enable --now node_exporter
+  systemctl enable --now prometheus
+  systemctl enable --now grafana-server
 fi
 
 echo

--- a/onevoice-storage/bluehost/provision.sh
+++ b/onevoice-storage/bluehost/provision.sh
@@ -436,6 +436,26 @@ server {
     client_max_body_size 512M;
     fastcgi_buffers 64 4K;
 
+    # No security headers are set here on purpose. Nextcloud emits its own
+    # (Referrer-Policy, X-Content-Type-Options, X-Frame-Options,
+    # X-Permitted-Cross-Domain-Policies, X-XSS-Protection, X-Robots-Tag, CSP)
+    # from PHP; adding X-Robots-Tag in nginx just sends it twice.
+    #
+    # Strict-Transport-Security is the one setupchecks still asks for, and it
+    # is deliberately omitted: this instance serves plain HTTP. Browsers only
+    # honour HSTS over HTTPS, and if it did apply it would pin clients to an
+    # https:// endpoint that does not exist. Add it with the Cloudflare Tunnel.
+
+    # Service-discovery endpoints. Without these, `occ setupchecks` warns and
+    # CalDAV/CardDAV desktop clients cannot autodiscover — they probe
+    # /.well-known/caldav and get Nextcloud's 404 page instead of a redirect.
+    # `location =` is an exact match and takes priority over the regex blocks
+    # below regardless of ordering.
+    location = /.well-known/carddav  { return 301 /remote.php/dav/; }
+    location = /.well-known/caldav   { return 301 /remote.php/dav/; }
+    location = /.well-known/webfinger { return 301 /index.php/.well-known/webfinger; }
+    location = /.well-known/nodeinfo  { return 301 /index.php/.well-known/nodeinfo; }
+
     location / {
         limit_req zone=nextcloud_limit burst=20 nodelay;
         rewrite ^ /index.php\$request_uri;
@@ -449,7 +469,29 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.*)\$;
         fastcgi_pass unix:/run/php-fpm/www.sock;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+        # fastcgi_split_path_info populates \$fastcgi_path_info, but nothing
+        # passes it on — stock fastcgi_params has no PATH_INFO. Routes that
+        # depend on it (WebDAV under /remote.php/dav/..., OCS under
+        # /ocs-provider/) then see an empty path.
+        fastcgi_param PATH_INFO \$fastcgi_path_info;
         include fastcgi_params;
+    }
+
+    # /ocs-provider/ and /updater/ are real directories served through their
+    # own index.php.
+    #
+    # This MUST come after the \\.php block above. nginx takes the first
+    # matching regex location, so placing it earlier makes it swallow
+    # /ocs-provider/index.php, and \`try_files \$uri/\` then looks for
+    # "/ocs-provider/index.php/" and 404s the very file it needs to serve.
+    # Here, the bare directory falls through to \`index index.php\`, which
+    # internally redirects to the .php handler above.
+    #
+    # ocm-provider is deliberately absent: Nextcloud 30 does not ship that
+    # directory, so it is left to the catch-all rewrite and the PHP router.
+    location ~ ^/(?:updater|ocs-provider)(?:\$|/) {
+        try_files \$uri \$uri/ =404;
+        index index.php;
     }
 
     # .mjs and .js.map have no entry in nginx's stock mime.types, so they are

--- a/onevoice-storage/bluehost/provision.sh
+++ b/onevoice-storage/bluehost/provision.sh
@@ -1,0 +1,713 @@
+#!/bin/bash
+#
+# provision.sh — OS-level provisioning for OneVoice Nextcloud on AlmaLinux 10.
+#
+# Refactor of onevoice-storage/packer/setup.sh, which ran as a Packer shell
+# provisioner against Amazon Linux 2023 to bake an AMI. There is no image to
+# bake on a Bluehost VPS, so this runs directly on the box.
+#
+# It keeps setup.sh's role: everything that does NOT need a secret. Installs
+# packages, lays down Nextcloud source, writes nginx/php config, installs
+# systemd units — but starts almost nothing and configures no application
+# state. configure.sh does that half.
+#
+# Idempotent: safe to re-run.
+#
+#   sudo ./provision.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${ENV_FILE:-/etc/onevoice/onevoice.env}"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "provision.sh must run as root." >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing $ENV_FILE. Copy onevoice.env.example there and fill it in." >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+SERVICE_USER="${SERVICE_USER:-onevoice}"
+SERVICE_HOME="/home/${SERVICE_USER}"
+NEXTCLOUD_VERSION="${NEXTCLOUD_VERSION:-30.0.0}"
+NEXTCLOUD_PATH="${NEXTCLOUD_PATH:-/var/www/nextcloud}"
+DB_MODE="${DB_MODE:-local}"
+OBJECT_STORE="${OBJECT_STORE:-local}"
+ENABLE_REDIS="${ENABLE_REDIS:-true}"
+ENABLE_CRON_TIMER="${ENABLE_CRON_TIMER:-true}"
+ENABLE_MCP="${ENABLE_MCP:-true}"
+ENABLE_CLOUDFLARED="${ENABLE_CLOUDFLARED:-true}"
+ENABLE_MAINTENANCE_TIMER="${ENABLE_MAINTENANCE_TIMER:-false}"
+OPEN_HTTP_PORT="${OPEN_HTTP_PORT:-false}"
+
+log() { echo -e "\n==> $*"; }
+
+# The EC2 build ran on a t3.medium with a known 4 GB and could hardcode sizes.
+# A Bluehost VPS plan can be 2 GB or less, where stock php-fpm (pm.max_children
+# = 50) plus a 512 MB InnoDB buffer pool plus Redis will hit the OOM killer
+# under any real load. Size both to the RAM actually present.
+TOTAL_MB="$(awk '/^MemTotal:/ {printf "%d", $2/1024}' /proc/meminfo)"
+
+INNODB_MB=$(( TOTAL_MB * 20 / 100 ))
+if [[ "$INNODB_MB" -lt 128 ]];  then INNODB_MB=128;  fi
+if [[ "$INNODB_MB" -gt 1024 ]]; then INNODB_MB=1024; fi
+
+# ~60 MB resident per Nextcloud php-fpm child, given ~40% of RAM to PHP.
+FPM_MAX_CHILDREN=$(( TOTAL_MB * 40 / 100 / 60 ))
+if [[ "$FPM_MAX_CHILDREN" -lt 4 ]];  then FPM_MAX_CHILDREN=4;  fi
+if [[ "$FPM_MAX_CHILDREN" -gt 50 ]]; then FPM_MAX_CHILDREN=50; fi
+FPM_START=$(( FPM_MAX_CHILDREN / 4 ));      if [[ "$FPM_START" -lt 2 ]]; then FPM_START=2; fi
+FPM_MIN_SPARE="$FPM_START"
+FPM_MAX_SPARE=$(( FPM_MAX_CHILDREN / 2 ));  if [[ "$FPM_MAX_SPARE" -lt 3 ]]; then FPM_MAX_SPARE=3; fi
+
+log "Detected ${TOTAL_MB} MB RAM -> InnoDB pool ${INNODB_MB}M, php-fpm max_children ${FPM_MAX_CHILDREN}"
+
+# The Bluehost image ships with ZERO swap. With no swap the OOM killer fires
+# immediately on any spike rather than degrading, and the processes it picks
+# are the big ones — MariaDB mid-install, or php-fpm mid-scan. Disk is the
+# cheap resource here (47 GB free), so trade a little of it for a soft edge.
+ENABLE_SWAPFILE="${ENABLE_SWAPFILE:-true}"
+SWAPFILE_MB="${SWAPFILE_MB:-2048}"
+if [[ "$ENABLE_SWAPFILE" == "true" ]]; then
+  CURRENT_SWAP="$(awk '/^SwapTotal:/ {printf "%d", $2/1024}' /proc/meminfo)"
+  if [[ "$CURRENT_SWAP" -gt 0 ]]; then
+    log "Swap already present (${CURRENT_SWAP} MB), leaving it alone"
+  else
+    log "No swap configured — creating a ${SWAPFILE_MB} MB swapfile"
+    if fallocate -l "${SWAPFILE_MB}M" /swapfile 2>/dev/null || \
+       dd if=/dev/zero of=/swapfile bs=1M count="$SWAPFILE_MB" status=none; then
+      chmod 600 /swapfile
+      mkswap /swapfile >/dev/null
+      swapon /swapfile
+      grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+      echo "    swap active: $(awk '/^SwapTotal:/ {printf "%d MB", $2/1024}' /proc/meminfo)"
+    else
+      echo "WARNING: could not create swapfile; continuing without swap." >&2
+      rm -f /swapfile
+    fi
+  fi
+fi
+
+# AlmaLinux splits packages across repos differently than Amazon Linux 2023,
+# and a few PHP extensions live under different names depending on whether
+# they come from AppStream, EPEL or Remi. Install the first name that resolves
+# rather than hardcoding a guess that breaks the whole `dnf install`.
+dnf_install_first() {
+  local pkg
+  for pkg in "$@"; do
+    if dnf -q list --available "$pkg" &>/dev/null || dnf -q list --installed "$pkg" &>/dev/null; then
+      dnf install -y "$pkg"
+      return 0
+    fi
+  done
+  echo "WARNING: none of these packages are available: $*" >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Base system
+# ---------------------------------------------------------------------------
+log "Updating base system"
+dnf update -y
+
+log "Installing base tooling"
+dnf install -y \
+  nginx unzip tar curl ca-certificates openssl \
+  policycoreutils-python-utils firewalld git
+
+# EPEL carries php-pecl-imagick and php-pecl-redis, which AppStream does not.
+# Best-effort: Nextcloud runs without them, it just files admin warnings.
+dnf install -y epel-release || echo "NOTE: EPEL unavailable; imagick/redis PHP extensions will be skipped."
+
+# ---------------------------------------------------------------------------
+# PHP
+# ---------------------------------------------------------------------------
+# Amazon Linux 2023 needed explicit php8.2-* package names.
+#
+# EL10 dropped DNF modules entirely. AlmaLinux 10 ships PHP 8.3 as the plain
+# `php` package (10.1 AppStream carries 8.3.26-1.el10_1) and offers 8.4 as a
+# SEPARATELY NAMED `php8.4` package — not a module stream. So a bare
+# `dnf install php` lands on 8.3, which is inside Nextcloud 30's supported
+# range (8.1-8.3, 8.3 recommended). Do not add php8.4 here.
+log "Installing PHP"
+
+# Core interpreter: these four genuinely must exist, so fail loudly if not.
+dnf install -y php php-fpm php-cli php-common
+
+# Extensions go in one at a time. A single renamed package in a combined
+# `dnf install` fails the ENTIRE transaction and aborts the run — and EL
+# extension naming is exactly the part that shifts between releases. Install
+# each best-effort; verify_php_extensions below is the real gate and knows the
+# difference between "required" and "nice to have".
+for _pkg in php-gd php-mbstring php-xml php-intl php-mysqlnd \
+            php-bcmath php-gmp php-opcache php-pdo php-process php-sodium; do
+  dnf_install_first "$_pkg" || true
+done
+
+# On EL the zip extension is php-pecl-zip (confirmed 1.22.3-5.el10 in
+# AlmaLinux 10 AppStream); a plain `php-zip` exists on Mageia/OpenMandriva but
+# not on Enterprise Linux. Several install guides claim otherwise, so try the
+# EL name first and fall through rather than trusting either.
+dnf_install_first php-pecl-zip php-zip || true
+# Optional performance/preview extensions.
+dnf_install_first php-pecl-imagick php-pecl-imagick-im7 || true
+REDIS_SERVICE=""
+if [[ "$ENABLE_REDIS" == "true" ]]; then
+  # EL10 has NO redis package. Redis Labs left open source at 7.4 (RSALv2 /
+  # SSPLv1), so RHEL 10 and every rebuild dropped it and ship Valkey, the
+  # community fork, in AppStream instead. Valkey is wire-, command- and
+  # on-disk-compatible, so the php-pecl-redis client and Nextcloud's
+  # \OC\Memcache\Redis backend talk to it unchanged — only the package and
+  # systemd unit are named differently.
+  # `|| true`: dnf_install_first returns 1 when nothing resolves, which would
+  # otherwise abort here instead of falling through to the warning below.
+  dnf_install_first valkey redis || true
+  # `systemctl cat`, NOT `systemctl list-unit-files | grep -q`. Under
+  # `set -o pipefail` that pipeline is racy: grep -q exits on first match and
+  # closes the pipe, which can SIGPIPE the still-writing systemctl (exit 141)
+  # and make the PIPELINE non-zero even though the match succeeded. It failed
+  # exactly that way here — detected valkey on one run, missed it on the next.
+  if systemctl cat valkey.service >/dev/null 2>&1; then
+    REDIS_SERVICE="valkey"
+  elif systemctl cat redis.service >/dev/null 2>&1; then
+    REDIS_SERVICE="redis"
+  else
+    echo "WARNING: neither valkey nor redis installed; caching will be skipped." >&2
+  fi
+  if [[ -n "$REDIS_SERVICE" ]]; then
+    log "Cache server: ${REDIS_SERVICE} (listens on 127.0.0.1:6379)"
+  fi
+
+  # The PHP client extension is still called redis regardless of the server.
+  dnf_install_first php-pecl-redis6 php-pecl-redis5 php-pecl-redis || true
+fi
+
+# Verify what actually LOADED, not what was named on the command line. Package
+# naming across EL rebuilds is the least reliable part of this script (php-zip
+# vs php-pecl-zip; curl bundled in php-common vs a separate php-curl), and a
+# missing extension otherwise surfaces as an opaque Nextcloud installer abort.
+# Anything still missing gets one automatic repair attempt under both naming
+# conventions before we give up.
+verify_php_extensions() {
+  local -a required=(
+    ctype curl dom fileinfo filter gd hash iconv json libxml mbstring
+    openssl pdo_mysql posix session simplexml xml xmlreader xmlwriter zip zlib
+  )
+  local -a recommended=(bcmath gmp intl sodium exif)
+  local loaded missing=() weak=() ext
+
+  loaded="$(php -m | tr '[:upper:]' '[:lower:]')"
+
+  for ext in "${required[@]}"; do
+    grep -qx "$ext" <<<"$loaded" || missing+=("$ext")
+  done
+  for ext in "${recommended[@]}"; do
+    grep -qx "$ext" <<<"$loaded" || weak+=("$ext")
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "Missing required PHP extensions: ${missing[*]} — attempting repair" >&2
+    for ext in "${missing[@]}"; do
+      dnf_install_first "php-${ext}" "php-pecl-${ext}" "php-${ext%%_*}" || true
+    done
+    loaded="$(php -m | tr '[:upper:]' '[:lower:]')"
+    missing=()
+    for ext in "${required[@]}"; do
+      grep -qx "$ext" <<<"$loaded" || missing+=("$ext")
+    done
+  fi
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    cat >&2 <<EOF
+
+ERROR: Nextcloud requires these PHP extensions and they are not loaded:
+       ${missing[*]}
+
+Find the package providing each, then re-run:
+       dnf provides '*/<extension>.so'
+       dnf search php | grep -i <extension>
+
+EOF
+    return 1
+  fi
+
+  echo "All required PHP extensions present."
+  if [[ ${#weak[@]} -gt 0 ]]; then
+    echo "NOTE: recommended but absent (admin warnings only): ${weak[*]}"
+  fi
+}
+verify_php_extensions
+
+PHP_VER="$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')"
+log "PHP version installed: $(php -r 'echo PHP_VERSION;')"
+
+# Guard, not an expected failure: AlmaLinux 10's `php` is 8.3 today, so this
+# should pass. It exists because Nextcloud hard-REFUSES to install on an
+# unsupported PHP major.minor (it is not a warning), and a future AlmaLinux
+# point release could repoint `php` at 8.4. Better to stop here in seconds
+# than after MariaDB and Nextcloud are half configured.
+NC_MAJOR="${NEXTCLOUD_VERSION%%.*}"
+if [[ "$NC_MAJOR" -le 30 ]] && [[ "$(printf '%s\n' "$PHP_VER" "8.3" | sort -V | tail -1)" != "8.3" ]]; then
+  cat >&2 <<EOF
+
+ERROR: PHP ${PHP_VER} is too new for Nextcloud ${NEXTCLOUD_VERSION}
+       (Nextcloud 30 supports PHP 8.1-8.3). The installer will refuse to run.
+
+Pick one, in /etc/onevoice/onevoice.env, then re-run:
+
+  1. Newer Nextcloud (recommended — 30 is past end-of-life anyway):
+       NEXTCLOUD_VERSION="31.0.8"      # supports PHP 8.1-8.4
+
+  2. Pin PHP 8.3 from Remi, keeping Nextcloud 30 for strict parity with the
+     EC2 build:
+       dnf install -y https://rpms.remirepo.net/enterprise/remi-release-10.rpm
+       dnf module reset php -y 2>/dev/null || true
+       dnf install -y php83 php83-php-fpm   # or enable the remi-8.3 stream
+     then re-run this script.
+
+EOF
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# MariaDB (replaces RDS)
+# ---------------------------------------------------------------------------
+if [[ "$DB_MODE" == "local" ]]; then
+  log "Installing MariaDB server"
+  # AlmaLinux 10 AppStream ships MariaDB 10.11 (lowercase `mariadb-server`;
+  # the upstream MariaDB repo uses capitalised `MariaDB-server`, don't mix).
+  # The client is listed explicitly because configure.sh invokes `mariadb`
+  # directly and we do not want to rely on it arriving as a dependency.
+  dnf install -y mariadb-server mariadb
+
+  # Nextcloud's documented MySQL requirements. READ-COMMITTED + ROW binlog
+  # avoid gap-lock deadlocks under concurrent uploads; RDS defaulted close
+  # enough to this that the EC2 build never had to say so explicitly.
+  cat > /etc/my.cnf.d/nextcloud.cnf <<EOF
+[mysqld]
+# MariaDB defaults to binding 0.0.0.0:3306 on EL. Nothing outside this host
+# needs it — Nextcloud connects over 127.0.0.1 — and firewalld is the only
+# thing keeping the database off the public internet. Bind to loopback so a
+# future firewall change cannot silently expose it. (The AWS build did not
+# need this: RDS lived in a private subnet behind a security group.)
+bind-address = 127.0.0.1
+
+transaction_isolation = READ-COMMITTED
+binlog_format         = ROW
+innodb_file_per_table = 1
+innodb_buffer_pool_size = ${INNODB_MB}M
+character_set_server  = utf8mb4
+collation_server      = utf8mb4_general_ci
+max_connections       = 200
+EOF
+
+  systemctl enable --now mariadb
+fi
+
+# ---------------------------------------------------------------------------
+# Service account (the "ec2-user" stand-in)
+# ---------------------------------------------------------------------------
+if ! id -u "$SERVICE_USER" &>/dev/null; then
+  log "Creating service account: $SERVICE_USER"
+  useradd --create-home --shell /bin/bash "$SERVICE_USER"
+fi
+
+# ---------------------------------------------------------------------------
+# Nextcloud source
+# ---------------------------------------------------------------------------
+if [[ -d "$NEXTCLOUD_PATH" ]]; then
+  log "Nextcloud already present at $NEXTCLOUD_PATH, leaving it alone"
+else
+  log "Downloading Nextcloud ${NEXTCLOUD_VERSION}"
+  cd /tmp
+  NC_ZIP="nextcloud-${NEXTCLOUD_VERSION}.zip"
+  NC_SUM="${NC_ZIP}.sha256"
+
+  curl -fsSL -o "$NC_SUM" "https://download.nextcloud.com/server/releases/${NC_SUM}"
+
+  # Reuse an archive already sitting in /tmp from an earlier run — the download
+  # is ~230 MB and re-fetching it on every retry makes iteration painful.
+  if [[ -f "$NC_ZIP" ]] && sha256sum --ignore-missing -c "$NC_SUM" >/dev/null 2>&1; then
+    echo "    reusing verified ${NC_ZIP} already in /tmp"
+  else
+    curl -fsSL -o "$NC_ZIP" "https://download.nextcloud.com/server/releases/${NC_ZIP}"
+  fi
+
+  # The AMI build skipped checksum verification because Packer ran on a
+  # trusted network at bake time. This box downloads at deploy time; verify.
+  #
+  # --ignore-missing is REQUIRED, not defensive: upstream's .sha256 lists both
+  # the zip AND a nextcloud-<ver>.metadata file that we deliberately do not
+  # fetch. Plain `sha256sum -c` exits 1 on the absent .metadata even when the
+  # zip itself reports OK, which under `set -e` aborts the run right before
+  # extraction.
+  sha256sum --ignore-missing -c "$NC_SUM"
+
+  mkdir -p "$(dirname "$NEXTCLOUD_PATH")"
+  unzip -q "$NC_ZIP" -d "$(dirname "$NEXTCLOUD_PATH")"
+  rm -f "$NC_ZIP" "$NC_SUM"
+fi
+
+log "Setting Nextcloud ownership and permissions"
+chown -R nginx:nginx "$NEXTCLOUD_PATH"
+find "$NEXTCLOUD_PATH/" -type d -exec chmod 750 {} \;
+find "$NEXTCLOUD_PATH/" -type f -exec chmod 640 {} \;
+
+if [[ "$OBJECT_STORE" == "local" ]]; then
+  DATA_DIR="${NEXTCLOUD_DATA_DIR:-${NEXTCLOUD_PATH}/data}"
+  mkdir -p "$DATA_DIR"
+  chown -R nginx:nginx "$DATA_DIR"
+  chmod 770 "$DATA_DIR"
+fi
+
+# ---------------------------------------------------------------------------
+# php-fpm
+# ---------------------------------------------------------------------------
+log "Configuring php-fpm"
+# EL ships www.conf owned by `apache`; the EC2 script made the same edits
+# because AL2023 does too.
+sed -i 's/^user = .*/user = nginx/'          /etc/php-fpm.d/www.conf
+sed -i 's/^group = .*/group = nginx/'        /etc/php-fpm.d/www.conf
+sed -i 's/^listen.owner = .*/listen.owner = nginx/' /etc/php-fpm.d/www.conf
+sed -i 's/^listen.group = .*/listen.group = nginx/' /etc/php-fpm.d/www.conf
+
+mkdir -p /var/lib/php/session
+chown -R nginx:nginx /var/lib/php/session
+chmod 700 /var/lib/php/session
+
+# Process-manager sizing. Stock EL ships pm.max_children = 50, which against
+# the 512M memory_limit below is a promise this box cannot keep.
+sed -i "s/^pm.max_children = .*/pm.max_children = ${FPM_MAX_CHILDREN}/"        /etc/php-fpm.d/www.conf
+sed -i "s/^pm.start_servers = .*/pm.start_servers = ${FPM_START}/"             /etc/php-fpm.d/www.conf
+sed -i "s/^pm.min_spare_servers = .*/pm.min_spare_servers = ${FPM_MIN_SPARE}/" /etc/php-fpm.d/www.conf
+sed -i "s/^pm.max_spare_servers = .*/pm.max_spare_servers = ${FPM_MAX_SPARE}/" /etc/php-fpm.d/www.conf
+
+# php.ini tuning. The EC2 build set memory_limit at boot time inside
+# user-data.sh; it belongs here with the rest of the static config.
+cat > /etc/php.d/99-nextcloud.ini <<'EOF'
+memory_limit = 512M
+upload_max_filesize = 512M
+post_max_size = 512M
+max_execution_time = 3600
+max_input_time = 3600
+output_buffering = 0
+date.timezone = UTC
+
+opcache.enable = 1
+opcache.enable_cli = 1
+opcache.interned_strings_buffer = 16
+opcache.max_accelerated_files = 10000
+opcache.memory_consumption = 128
+opcache.save_comments = 1
+opcache.revalidate_freq = 60
+EOF
+
+# ---------------------------------------------------------------------------
+# nginx
+# ---------------------------------------------------------------------------
+log "Configuring nginx"
+install -m 0644 "$SCRIPT_DIR/files/rate-limit.conf" /etc/nginx/conf.d/rate-limit.conf
+
+# Structurally the AMI's server block, with ONE addition: the `types` map.
+#
+# Nextcloud's own `occ setupchecks` flags the stock config with a hard failure
+# on this box — "Your webserver does not serve .mjs files using the JavaScript
+# MIME type. This will break some apps". nginx's default mime.types has no
+# entry for .mjs, so it serves them as application/octet-stream and browsers
+# refuse to execute them. The AMI's `location ~ \.(?:css|js|mjs|...)$` block
+# matches .mjs for caching but never sets its type.
+#
+# This affects the EC2 deployment identically — worth fixing there too.
+#
+# Still absent, and still matching prod: .well-known/{caldav,carddav}
+# redirects and the PATH_INFO fastcgi_param. Those are warnings rather than
+# failures; see README.
+cat > /etc/nginx/conf.d/nextcloud.conf <<EOF
+server {
+    listen 80;
+    server_name _;
+    root ${NEXTCLOUD_PATH};
+
+    client_max_body_size 512M;
+    fastcgi_buffers 64 4K;
+
+    location / {
+        limit_req zone=nextcloud_limit burst=20 nodelay;
+        rewrite ^ /index.php\$request_uri;
+    }
+
+    location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)/ {
+        deny all;
+    }
+
+    location ~ \.php(?:\$|/) {
+        fastcgi_split_path_info ^(.+\.php)(/.*)\$;
+        fastcgi_pass unix:/run/php-fpm/www.sock;
+        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    # .mjs and .js.map have no entry in nginx's stock mime.types, so they are
+    # served as application/octet-stream and browsers refuse to execute them
+    # (occ setupchecks flags .mjs as a hard failure).
+    #
+    # Fixed with per-location default_type, NOT a \`types { }\` block. A types
+    # block REPLACES the entire inherited MIME map for its context rather than
+    # extending it — doing that here silently turned every .css into
+    # octet-stream and rendered the whole UI unstyled. Regex locations match
+    # in order, so these two must precede the general static block below.
+    location ~ \.mjs\$ {
+        default_type text/javascript;
+        expires 30d;
+        access_log off;
+    }
+
+    location ~ \.map\$ {
+        default_type application/json;
+        expires 30d;
+        access_log off;
+    }
+
+    location ~ \.(?:css|js|svg|gif|png|jpg|ico|woff2?)\$ {
+        expires 30d;
+        access_log off;
+    }
+}
+EOF
+
+rm -f /etc/nginx/conf.d/default.conf 2>/dev/null || true
+
+# AlmaLinux's stock nginx.conf carries its own `server {}` on :80 serving the
+# distro welcome page; Amazon Linux 2023's does not, so the EC2 build never
+# had to deal with it. Ours wins on ordering today (conf.d is included above
+# that block), but that is a fragile thing to depend on — comment it out.
+#
+# Brace-counting rather than a sed line range: the stock block contains nested
+# `location { }` blocks, so a `/server {/,/^\s*}/` range would terminate on the
+# first nested closing brace and leave a syntactically broken file behind.
+if grep -qE '^[[:space:]]*server[[:space:]]*\{' /etc/nginx/nginx.conf; then
+  log "Commenting out the stock nginx default server block"
+  cp -n /etc/nginx/nginx.conf /etc/nginx/nginx.conf.orig
+  awk '
+    BEGIN { depth = 0; inserver = 0 }
+    {
+      if (!inserver && $0 ~ /^[[:space:]]*server[[:space:]]*\{/) { inserver = 1; depth = 0 }
+      if (inserver) {
+        line = $0
+        depth += gsub(/\{/, "{")
+        depth -= gsub(/\}/, "}")
+        print "#" line
+        if (depth <= 0) { inserver = 0 }
+        next
+      }
+      print
+    }
+  ' /etc/nginx/nginx.conf > /etc/nginx/.nginx.conf.new
+
+  # Stage the temp file in /etc/nginx, NOT /tmp. `mv` preserves the SOURCE's
+  # SELinux context, so moving in from /tmp lands the file labelled
+  # user_tmp_t instead of httpd_config_t. nginx then fails to start with
+  #   open() "/etc/nginx/nginx.conf" failed (13: Permission denied)
+  # while `nginx -t` as unconfined root still passes — a genuinely confusing
+  # pair of symptoms. Creating it inside /etc/nginx inherits the right label;
+  # restorecon is belt-and-braces.
+  chmod 0644 /etc/nginx/.nginx.conf.new
+  mv /etc/nginx/.nginx.conf.new /etc/nginx/nginx.conf
+  restorecon -F /etc/nginx/nginx.conf 2>/dev/null || true
+fi
+
+nginx -t
+
+# ---------------------------------------------------------------------------
+# SELinux
+# ---------------------------------------------------------------------------
+# The single biggest AL2023 -> AlmaLinux difference. Amazon Linux 2023 boots
+# SELinux permissive, so the EC2 scripts never needed a line of this.
+# AlmaLinux 10 boots ENFORCING: without the rules below, nginx cannot read
+# the docroot, php-fpm cannot write config/ or data/, and every outbound S3
+# call is denied.
+if command -v getenforce &>/dev/null && [[ "$(getenforce)" != "Disabled" ]]; then
+  log "Applying SELinux policy for Nextcloud (mode: $(getenforce))"
+
+  semanage fcontext -a -t httpd_sys_rw_content_t "${NEXTCLOUD_PATH}/config(/.*)?"   2>/dev/null || true
+  semanage fcontext -a -t httpd_sys_rw_content_t "${NEXTCLOUD_PATH}/apps(/.*)?"     2>/dev/null || true
+  semanage fcontext -a -t httpd_sys_rw_content_t "${NEXTCLOUD_PATH}/.htaccess"      2>/dev/null || true
+  semanage fcontext -a -t httpd_sys_rw_content_t "${NEXTCLOUD_PATH}/.user.ini"      2>/dev/null || true
+  semanage fcontext -a -t httpd_sys_rw_content_t \
+    "${NEXTCLOUD_PATH}/3rdparty/aws/aws-sdk-php/src/data/logs(/.*)?"                2>/dev/null || true
+  if [[ "$OBJECT_STORE" == "local" ]]; then
+    semanage fcontext -a -t httpd_sys_rw_content_t "${NEXTCLOUD_DATA_DIR:-$NEXTCLOUD_PATH/data}(/.*)?" 2>/dev/null || true
+  fi
+
+  restorecon -R "$NEXTCLOUD_PATH" >/dev/null 2>&1 || true
+  if [[ "$OBJECT_STORE" == "local" ]]; then
+    restorecon -R "${NEXTCLOUD_DATA_DIR:-$NEXTCLOUD_PATH/data}" >/dev/null 2>&1 || true
+  fi
+
+  # Outbound HTTP from php-fpm: S3 object store, files_external, app store,
+  # update checks. Denied by default.
+  setsebool -P httpd_can_network_connect on
+  # php-fpm -> MariaDB over TCP on 127.0.0.1.
+  setsebool -P httpd_can_network_connect_db on
+  if [[ "$ENABLE_REDIS" == "true" ]]; then
+    setsebool -P httpd_can_network_memcache on
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# firewalld
+# ---------------------------------------------------------------------------
+# Also absent on Amazon Linux 2023 — inbound filtering there was the EC2
+# security group's job, which is a Terraform resource, not a script concern.
+# A stock Bluehost AlmaLinux image ships firewalld NOT INSTALLED and not
+# running — so this does not "configure the firewall", it INTRODUCES one where
+# no filtering existed. Over SSH that is the classic way to lock yourself out
+# of a remote box permanently.
+#
+# Allow SSH offline, before the daemon ever starts, so there is no window in
+# which the running ruleset lacks it. firewalld's default public zone does
+# permit ssh, but relying on a default you cannot recover from is a bad trade
+# for one extra line.
+log "Enabling firewalld (ensuring SSH survives first)"
+firewall-offline-cmd --add-service=ssh >/dev/null 2>&1 || true
+systemctl enable --now firewalld
+firewall-cmd --permanent --add-service=ssh >/dev/null
+
+if [[ "$OPEN_HTTP_PORT" == "true" ]]; then
+  log "Opening 80/tcp"
+  firewall-cmd --permanent --add-service=http >/dev/null
+else
+  log "Leaving 80/tcp closed — Cloudflare Tunnel is outbound-only and needs no inbound port"
+fi
+firewall-cmd --reload >/dev/null
+
+echo "    active services: $(firewall-cmd --list-services)"
+
+# ---------------------------------------------------------------------------
+# cloudflared
+# ---------------------------------------------------------------------------
+if [[ "$ENABLE_CLOUDFLARED" == "true" ]]; then
+  log "Installing cloudflared"
+  curl -fsSL https://pkg.cloudflare.com/cloudflared-ascii.repo -o /etc/yum.repos.d/cloudflared.repo
+  dnf install -y cloudflared
+  install -m 0644 "$SCRIPT_DIR/files/cloudflared.service" /etc/systemd/system/cloudflared.service
+fi
+
+# ---------------------------------------------------------------------------
+# GitHub CLI (maintenance automation)
+# ---------------------------------------------------------------------------
+if [[ "$ENABLE_MAINTENANCE_TIMER" == "true" ]]; then
+  log "Installing GitHub CLI"
+  # AlmaLinux 10 uses DNF5, where the plugin lives in `dnf5-plugins` and the
+  # old `dnf-command(config-manager)` provides-name may not resolve.
+  dnf install -y 'dnf-command(config-manager)' 2>/dev/null \
+    || dnf install -y dnf5-plugins \
+    || true
+  # DNF5 also renamed the subcommand: `config-manager addrepo --from-repofile=`
+  # replaced `config-manager --add-repo`.
+  dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo 2>/dev/null \
+    || dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+  dnf install -y gh --repo gh-cli
+fi
+
+# ---------------------------------------------------------------------------
+# Nextcloud MCP server
+# ---------------------------------------------------------------------------
+if [[ "$ENABLE_MCP" == "true" ]]; then
+  log "Installing nextcloud-mcp-server"
+  # github.com/cbcoutinho/nextcloud-mcp-server: full clone + uv sync, not a
+  # standalone uv-managed dependency project.
+  if [[ ! -x "${SERVICE_HOME}/.local/bin/uv" ]]; then
+    sudo -u "$SERVICE_USER" bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+  fi
+  if [[ ! -d "${SERVICE_HOME}/nextcloud-mcp-server" ]]; then
+    sudo -u "$SERVICE_USER" git clone \
+      https://github.com/cbcoutinho/nextcloud-mcp-server.git \
+      "${SERVICE_HOME}/nextcloud-mcp-server"
+  fi
+  sudo -u "$SERVICE_USER" bash -c "cd '${SERVICE_HOME}/nextcloud-mcp-server' && '${SERVICE_HOME}/.local/bin/uv' sync"
+fi
+
+# ---------------------------------------------------------------------------
+# Scripts + systemd units
+# ---------------------------------------------------------------------------
+log "Installing scripts and systemd units"
+
+install -d -o "$SERVICE_USER" -g "$SERVICE_USER" -m 0755 "${SERVICE_HOME}/scripts"
+install -o "$SERVICE_USER" -g "$SERVICE_USER" -m 0700 \
+  "$SCRIPT_DIR/files/nextcloud-maintenance-check.sh" \
+  "${SERVICE_HOME}/scripts/nextcloud-maintenance-check.sh"
+
+# The unit files ship with placeholders instead of a hardcoded /home/ec2-user,
+# so the service account is configurable rather than baked into the AMI.
+render_unit() {
+  local src="$1" dest="$2"
+  sed -e "s|__SERVICE_USER__|${SERVICE_USER}|g" \
+      -e "s|__SERVICE_HOME__|${SERVICE_HOME}|g" \
+      -e "s|__NEXTCLOUD_PATH__|${NEXTCLOUD_PATH}|g" \
+      -e "s|__ENV_FILE__|${ENV_FILE}|g" \
+      "$src" > "$dest"
+  chmod 0644 "$dest"
+}
+
+if [[ "$ENABLE_MCP" == "true" ]]; then
+  render_unit "$SCRIPT_DIR/files/nextcloud-mcp.service" /etc/systemd/system/nextcloud-mcp.service
+fi
+
+if [[ "$ENABLE_MAINTENANCE_TIMER" == "true" ]]; then
+  render_unit "$SCRIPT_DIR/files/nextcloud-maintenance.service" /etc/systemd/system/nextcloud-maintenance.service
+  render_unit "$SCRIPT_DIR/files/nextcloud-maintenance.timer"   /etc/systemd/system/nextcloud-maintenance.timer
+
+  # The maintenance script shells out to `sudo -u nginx php occ` and
+  # `sudo dnf check-update`. ec2-user had blanket NOPASSWD sudo from the AMI;
+  # this account gets only what the script actually calls.
+  cat > /etc/sudoers.d/onevoice-maintenance <<EOF
+${SERVICE_USER} ALL=(nginx) NOPASSWD: /usr/bin/php ${NEXTCLOUD_PATH}/occ *
+${SERVICE_USER} ALL=(root)  NOPASSWD: /usr/bin/dnf check-update
+EOF
+  chmod 0440 /etc/sudoers.d/onevoice-maintenance
+  visudo -cf /etc/sudoers.d/onevoice-maintenance
+fi
+
+if [[ "$ENABLE_CRON_TIMER" == "true" ]]; then
+  render_unit "$SCRIPT_DIR/files/nextcloud-cron.service" /etc/systemd/system/nextcloud-cron.service
+  render_unit "$SCRIPT_DIR/files/nextcloud-cron.timer"   /etc/systemd/system/nextcloud-cron.timer
+fi
+
+systemctl daemon-reload
+
+log "Enabling services"
+# Full `if` blocks rather than `[[ cond ]] && systemctl ...` one-liners. Under
+# `set -e` a false condition in an AND-list does NOT abort (bash exempts a
+# failed non-final element), but the list still evaluates to 1 — so such a
+# line sitting last in a script or function silently makes it report failure.
+# bootstrap.sh chains these two scripts, so exit status has to mean something.
+systemctl enable nginx
+systemctl enable php-fpm
+
+if [[ "$ENABLE_REDIS" == "true" && -n "$REDIS_SERVICE" ]]; then
+  systemctl enable --now "$REDIS_SERVICE"
+fi
+if [[ "$ENABLE_CLOUDFLARED" == "true" ]]; then
+  systemctl enable cloudflared
+fi
+if [[ "$ENABLE_MCP" == "true" ]]; then
+  systemctl enable nextcloud-mcp
+fi
+# maintenance/cron .service units are oneshots driven by their timers, never
+# enabled directly.
+if [[ "$ENABLE_MAINTENANCE_TIMER" == "true" ]]; then
+  systemctl enable nextcloud-maintenance.timer
+fi
+if [[ "$ENABLE_CRON_TIMER" == "true" ]]; then
+  systemctl enable nextcloud-cron.timer
+fi
+
+echo
+echo "Nextcloud OS provisioning complete."
+echo "Next: sudo ./configure.sh"


### PR DESCRIPTION
Ports the Nextcloud deployment off EC2 onto a Bluehost VPS (AlmaLinux 10.2, 4 GB / 2 vCPU / 50 GB). **Deployed and verified end to end** at `https://cloud.knoch.dev`.

Closes #57

## Why the AMI was not reused

`aws ec2 export-image` refuses images derived from AWS-provided Linux AMIs, and `nextcloud.pkr.hcl` builds from `al2023-ami-*`. Bluehost VPS does not accept custom disk images either. Even setting both aside, roughly half the AMI's value is AWS-coupled — IMDS instance profile for S3, SSM for every secret, an RDS endpoint. **The scripts are the portable artifact, not the image.**

The AWS scripts are deliberately **left untouched** here; prod is live behind that tunnel, and making `setup.sh` dual-target risks a working deployment to serve a clone. Parity fixes for the EC2 side are raised separately in #58.

| AWS | Bluehost | Role |
| --- | --- | --- |
| `packer/setup.sh` (bake time) | `bluehost/provision.sh` | OS, packages, nginx/php, systemd. No secrets. |
| `terraform/scripts/user-data.sh` (cloud-init) | `bluehost/configure.sh` | DB, install, theming, users. All secrets. |
| SSM + `templatefile()` | `/etc/onevoice/onevoice.env` (gitignored) | Config and secret input |

## EL10 platform facts, verified against the live host

AlmaLinux 10 is not a small step from Amazon Linux 2023:

| Thing | Reality | Consequence |
| --- | --- | --- |
| SELinux | **enforcing** (AL2023 is permissive) | Without fcontext rules and `httpd_can_network_*`, nginx cannot read the docroot and php-fpm cannot write `config/` |
| firewalld | present but **not installed/running** | Enabling it *introduces* filtering. SSH is allowed offline before the daemon starts, so a remote run cannot lock itself out |
| PHP | no DNF modules; `php` is 8.3.32, 8.4 is a separate `php8.4` package | Bare `dnf install php` lands in Nextcloud 30's supported range |
| zip | `php-zip` does not exist on EL — it is `php-pecl-zip` | Popular guides are wrong for EL |
| curl | no `php-curl`; bundled in `php-common` | Same |
| Redis | **removed** after the 7.4 licence change; EL10 ships **Valkey** | `dnf install redis` fails outright |
| MariaDB | 10.11; `mysql.user` is a non-updatable view | Classic `DELETE FROM mysql.user` hardening fails |

Because package naming is the least reliable part, `provision.sh` verifies **loaded extensions** via `php -m`, attempts one repair under both naming conventions, and fails with the specific missing list.

## Storage

Primary storage is **local disk, not B2** — deliberately. `knoch-nextcloud-storage` already contains files, and a primary object store keys objects `urn:oid:<fileid>` from its own database with no concept of real paths. Per the admin manual: *"Configuring a primary object store on an existing Nextcloud instance will make all existing files on the instance inaccessible."* B2 is mounted as **external storage**, which addresses by real path and preserves them. One bucket cannot serve both roles.

External storage does **not** keep Nextcloud off local disk — previews for mounted files cache locally, and chunked uploads stage locally before being written to B2. Preview and log caps bound growth on the 50 GB volume.

## Also included

**Monitoring** — Prometheus + node_exporter + Grafana, all bound to **loopback**. Prometheus has no authentication of any kind and is never exposed; only Grafana gets a tunnel hostname. Measured cost 270 MB.

**Outbound email** — nine `mail_*` settings via SES, with an explicit "not configured" notice when disabled, because Nextcloud fails *silently* without it.

**Camera RAW** — a mimetype alias plus two app patches that make RAW files open rather than download. Both patches existed by hand on EC2 since July, recorded nowhere; rediscovering them cost about an hour, which is why they are scripted now.

## Bugs found by running it

- `sha256sum -c` aborted the run: upstream's `.sha256` lists a `.metadata` file we never fetch, so it exited 1 despite the zip verifying OK
- `systemctl list-unit-files | grep -q` under `pipefail` is **racy** — `grep -q` exits on match and SIGPIPEs the producer, failing the pipeline on success. Made Valkey detection intermittent. Fixed in four places.
- `nginx.conf` staged in `/tmp` then `mv`'d arrived labelled `user_tmp_t`; nginx failed `EACCES` while `nginx -t` as root passed
- `.mjs` served as `octet-stream` — and the first fix, a `types {}` block, **replaced** the inherited MIME map instead of extending it, serving every `.css` as octet-stream and leaving the UI unstyled
- Grafana confined as `grafana_t` cannot reach Prometheus without `grafana_can_tcp_connect_prometheus_port`; the symptom reads like a network fault, and testing by hand misleads because a shell runs unconfined
- `OPEN_HTTP_PORT` was add-only, so flipping it to false left 80/tcp open while the config claimed otherwise

## Verification

- `occ setupchecks` reports **no failures**; two warnings remain by design (HSTS pending, historical build-time log errors)
- Externally reachable ports: **22 only**. 80, 443, 3000, 9090, 9100 all closed
- `https://cloud.knoch.dev/login` → 200
- B2 mount verifies `status: ok`; all 11 users created
- Prometheus targets up; `node_memory_MemAvailable_bytes` returns real data

## Status

Destination environment is **functional**. Data porting from the EC2 instance is deferred until after the OneVoice group meeting on **Saturday 2026-08-22**. Nothing here touches the running EC2 instance.
