### PR TITLE
docs: architecture diagrams for both deployment targets (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Neither depends on the other. The AWS stack came first; the Bluehost target exis
 
 Both are applied manually/locally — no CI/CD.
 
+**Diagrams for both, and for what differs between them:** [`docs/architecture.md`](docs/architecture.md).
+
 ## Why this exists
 
 OneVoice is a gospel/choir group, and for a while all of the group's shared files — recordings, sheet music, event media, admin docs — lived in one member's personal Dropbox account. That meant one personal login shared around the group (or worse, credentials passed along informally), no real way to control who had access to what, and no accountability if something got deleted or someone left. It worked, in the sense that files existed somewhere, but it was never actually *ours* — the group's storage was one person's liability. It was unsecure and honestly kind of hectic to manage.

--- a/aws/README.md
+++ b/aws/README.md
@@ -6,6 +6,8 @@ For *why* this shape — S3 over EBS, a single EC2 instance over containers/K8s/
 
 The other deployment target is [`bluehost/`](../bluehost/README.md). Nothing here depends on it.
 
+A diagram of this stack — VPC, subnets, the four managed-service relationships and the account-wide pieces — is in [`docs/architecture.md`](../docs/architecture.md).
+
 ## Layout
 
 ```

--- a/bluehost/README.md
+++ b/bluehost/README.md
@@ -4,6 +4,9 @@ A port of the AWS deployment to a plain VPS. Same Nextcloud, same theming,
 same seed users, same Cloudflare Tunnel front door — none of the AWS control
 plane.
 
+A diagram of this host, and a side-by-side of the six roles that differ from
+the AWS build, is in [`docs/architecture.md`](../docs/architecture.md).
+
 ## Why there is no image to copy
 
 The AMI cannot be moved to Bluehost, for two independent reasons:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,108 @@
+# Architecture
+
+Diagrams of the two deployment targets, and of what actually differs between
+them. Drawn from the Terraform and the provisioning scripts, not from memory —
+if the code and a diagram disagree, the code is right and the diagram is stale.
+
+Sources are single SVG files in [`diagrams/`](diagrams/). They render inline on
+GitHub, open in any browser, and follow your light/dark setting. They are plain
+text, so they diff and review like code.
+
+| File | Shows |
+| --- | --- |
+| [`aws-architecture.svg`](diagrams/aws-architecture.svg) | The AWS stack: VPC, EC2, RDS, the two buckets, the managed control plane |
+| [`bluehost-architecture.svg`](diagrams/bluehost-architecture.svg) | The Bluehost VPS: one host, every service local, B2 and SES outbound |
+| [`deployment-comparison.svg`](diagrams/deployment-comparison.svg) | The shared application spine and the six roles that swap |
+
+---
+
+## AWS — `onevoice.knoch.dev`
+
+![AWS architecture](diagrams/aws-architecture.svg)
+
+**The request path is short and the control plane is wide.** Public traffic
+never enters through the IGW — `cloudflared` dials out to Cloudflare, so the
+security group's 80/443 rules are open to the world but carry nothing.
+
+The four diagonals are the instance's four managed-service relationships, and
+each is a deliberately different auth story:
+
+- **primary bucket** — the EC2 instance role, no static keys anywhere on disk;
+- **migration bucket** — a scoped IAM *user* with an access key, because
+  Nextcloud's External Storage app cannot use an instance role;
+- **SSM Parameter Store** — eight SecureStrings, read once at first boot;
+- **CloudWatch** — the agent pushing memory and disk, which EC2 does not
+  publish itself.
+
+Two things the diagram shows that are worth knowing before you touch the
+network:
+
+- The **S3 gateway endpoint is routed on `priv-rt` only**
+  ([`vpc.tf`](../aws/terraform/vpc.tf)), but the instance sits in `pub-a` on
+  `main-rt` ([`compute.tf`](../aws/terraform/compute.tf)) — so its S3 traffic
+  leaves through the internet gateway, not the endpoint.
+- **`nextcloud-sg` opens 80/443 to `0.0.0.0/0`** while the tunnel is
+  outbound-only. Those rules carry no traffic, but the instance does have a
+  public IP.
+
+Operational detail, secrets layout and the gotcha log: [`aws/README.md`](../aws/README.md).
+
+---
+
+## Bluehost VPS — `cloud.knoch.dev`
+
+![Bluehost VPS architecture](diagrams/bluehost-architecture.svg)
+
+**Everything AWS managed for the other host is now a process inside this box.**
+The stack is closed to the outside: firewalld admits only SSH, and the sole way
+a request reaches nginx is back down the tunnel `cloudflared` opened.
+
+- **SELinux enforcing** is the single largest departure from Amazon Linux.
+  Without the `semanage fcontext` rules and the `httpd_can_network_*` booleans
+  in `provision.sh`, nginx cannot read the docroot, php-fpm cannot write
+  `config/`, and every outbound S3 call is denied.
+- **B2 does not keep Nextcloud off the local volume.** Previews, chunked-upload
+  staging and `oc_filecache` all land on the 50 GB disk — previews are the one
+  that will fill it.
+- **MCP and the maintenance timer are off here** so two hosts don't file
+  duplicate monthly issues and PRs.
+
+Install steps, the `onevoice.env` shape and the EL10 platform facts:
+[`bluehost/README.md`](../bluehost/README.md).
+
+---
+
+## What actually swaps
+
+![One application, two substrates](diagrams/deployment-comparison.svg)
+
+Comparing the two diagrams box for box overstates the difference. The
+application layer is genuinely identical — same Nextcloud 30, same theming and
+seed users, and an nginx server block that is byte-identical between the two.
+What changes is which thing fills six supporting roles, and whether that thing
+is a Terraform resource or a line in a shell script.
+
+Read a row across and you have the whole porting decision for that role. The
+rows are not interchangeable in cost or blast radius:
+
+- **Swapping the database was forced.** Pointing this clone at prod's RDS would
+  not produce a copy — it would attach a second Nextcloud to prod's
+  `oc_filecache` with a different data directory, corrupting both.
+- **Swapping object-store auth was mechanical.** A VPS has no IMDS, so there is
+  no instance role to read and an explicit key becomes mandatory.
+
+---
+
+## Keeping these current
+
+The diagrams are hand-authored SVG — no build step, no toolchain, no export.
+Edit the `<text>` and coordinates directly and the change shows up in the next
+GitHub render.
+
+Update them when any of these change, since each is drawn explicitly:
+
+- instance type, RDS class, or subnet CIDRs;
+- the set of SSM parameters, or where secrets come from on either host;
+- which services run on the instance (the six chips inside the EC2 box);
+- the CloudWatch alarm set, or anything about the alerting path;
+- an `onevoice.env` flag that turns a component on or off.

--- a/docs/diagrams/aws-architecture.svg
+++ b/docs/diagrams/aws-architecture.svg
@@ -1,0 +1,177 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -56 1160 976" role="img" aria-label="AWS architecture: users reach Cloudflare, which reaches a single EC2 instance in a public subnet through an outbound Cloudflare Tunnel. The instance talks to RDS MySQL in private subnets, two S3 buckets, SSM Parameter Store and CloudWatch.">
+<title>OneVoice Nextcloud on AWS — us-east-1</title>
+<style>
+svg{
+  --ground:#F1F3F6; --surface:#FFFFFF; --surface-2:#E6EAF0;
+  --ink:#141920; --muted:#59636F; --line-strong:#A9B2BF;
+  --tunnel:#B0602A; --managed:#42517A; --risk:#A03D28; --ok:#346C4B;
+  --sans:ui-sans-serif,-apple-system,"Segoe UI",Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,SFMono-Regular,Consolas,"Liberation Mono",monospace;
+}
+@media (prefers-color-scheme:dark){
+  svg{
+    --ground:#0D1116; --surface:#161B22; --surface-2:#1F252E;
+    --ink:#E2E7EE; --muted:#8E99A8; --line-strong:#414B58;
+    --tunnel:#E39159; --managed:#93A2D4; --risk:#E0836B; --ok:#6EBB8C;
+  }
+}
+.bg{fill:var(--ground)}
+text{font-family:var(--mono);fill:var(--ink)}
+.h1{font-family:var(--sans);font-size:16px;font-weight:700;letter-spacing:-.01em}
+.h2{font-size:10.5px;fill:var(--muted);letter-spacing:.08em}
+.t-ttl{font-family:var(--sans);font-size:13px;font-weight:600}
+.t-sub{font-size:10.5px;fill:var(--muted)}
+.t-chip{font-size:10.5px}
+.t-frame{font-family:var(--sans);font-size:10.5px;font-weight:600;fill:var(--muted);letter-spacing:.12em}
+.t-lab{font-size:10px;fill:var(--muted)}
+.t-tun{font-size:10px;fill:var(--tunnel)}
+.t-risk{font-size:10.5px;fill:var(--risk)}
+.t-ok{font-size:10.5px;fill:var(--ok)}
+.box{fill:var(--surface);stroke:var(--line-strong);stroke-width:1}
+.box-2{fill:var(--surface-2);stroke:var(--line-strong);stroke-width:1}
+.box-m{fill:var(--surface);stroke:var(--managed);stroke-width:1.5}
+.frame{fill:none;stroke:var(--line-strong);stroke-width:1;stroke-dasharray:5 4}
+.frame-solid{fill:none;stroke:var(--line-strong);stroke-width:1.5}
+.chipbox{fill:var(--surface-2);stroke:none}
+.link{stroke:var(--line-strong);stroke-width:1.4;fill:none}
+.tun{stroke:var(--tunnel);stroke-width:2;fill:none}
+marker path{fill:var(--line-strong)}
+marker.mt path{fill:var(--tunnel)}
+</style>
+<defs>
+  <marker id="ah1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z"/></marker>
+  <marker id="aht1" class="mt" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z"/></marker>
+</defs>
+
+<rect class="bg" x="0" y="-56" width="1160" height="976"/>
+<text class="h1" x="40" y="-30">OneVoice Nextcloud — AWS deployment</text>
+<text class="h2" x="40" y="-12">ONEVOICE.KNOCH.DEV · US-EAST-1 · TERRAFORM + PACKER GOLDEN AMI</text>
+
+<rect class="box" x="40" y="28" width="130" height="56"/>
+<text class="t-ttl" x="56" y="52">People</text>
+<text class="t-sub" x="56" y="68">browser · desktop</text>
+
+<line class="link" x1="170" y1="56" x2="302" y2="56" marker-end="url(#ah1)"/>
+<text class="t-lab" x="236" y="46" text-anchor="middle">onevoice.knoch.dev</text>
+
+<rect class="box" x="310" y="28" width="220" height="56"/>
+<text class="t-ttl" x="326" y="52">Cloudflare edge</text>
+<text class="t-sub" x="326" y="68">TLS terminates here</text>
+
+<rect class="frame" x="40" y="120" width="1080" height="780"/>
+<text class="t-frame" x="54" y="142">AWS ACCOUNT · US-EAST-1</text>
+
+<rect class="frame-solid" x="64" y="166" width="520" height="650"/>
+<text class="t-frame" x="78" y="188">VPC · 10.30.0.0/16</text>
+
+<rect class="box" x="88" y="200" width="110" height="42"/>
+<text class="t-chip" x="103" y="226">IGW</text>
+
+<rect class="frame" x="88" y="262" width="472" height="280"/>
+<text class="t-frame" x="102" y="282">SUBNET PUB-A · 10.30.1.0/28 · AZ-A</text>
+
+<rect class="box-m" x="110" y="290" width="300" height="64"/>
+<text class="t-chip" x="124" y="310">nextcloud-sg</text>
+<text class="t-risk" x="124" y="326">in 80/443 ← 0.0.0.0/0 (unused)</text>
+<text class="t-sub" x="124" y="342">in 22 ← 70.21.84.34/32 · out all</text>
+
+<rect class="box" x="110" y="376" width="428" height="148"/>
+<text class="t-ttl" x="124" y="398">EC2 · t3.medium</text>
+<text class="t-sub" x="124" y="413">booted from the Packer golden AMI</text>
+<rect class="chipbox" x="124" y="424" width="196" height="26"/>
+<text class="t-chip" x="134" y="441">nginx + rate-limit</text>
+<rect class="chipbox" x="328" y="424" width="196" height="26"/>
+<text class="t-chip" x="338" y="441">cloudflared</text>
+<rect class="chipbox" x="124" y="456" width="196" height="26"/>
+<text class="t-chip" x="134" y="473">php-fpm 8.2</text>
+<rect class="chipbox" x="328" y="456" width="196" height="26"/>
+<text class="t-chip" x="338" y="473">CloudWatch agent</text>
+<rect class="chipbox" x="124" y="488" width="196" height="26"/>
+<text class="t-chip" x="134" y="505">Nextcloud 30</text>
+<rect class="chipbox" x="328" y="488" width="196" height="26"/>
+<text class="t-chip" x="338" y="505">MCP + maint. timer</text>
+
+<line class="tun" x1="470" y1="376" x2="470" y2="88" marker-end="url(#aht1)"/>
+<text class="t-tun" x="482" y="232">outbound 443</text>
+<text class="t-tun" x="482" y="246">requests ride back down</text>
+
+<rect class="frame" x="88" y="572" width="472" height="150"/>
+<text class="t-frame" x="102" y="592">PRIV-A 10.30.3.0/28 · PRIV-B 10.30.4.0/28</text>
+
+<line class="link" x1="216" y1="524" x2="216" y2="608" marker-end="url(#ah1)"/>
+<text class="t-lab" x="226" y="570">3306</text>
+
+<rect class="box" x="110" y="610" width="212" height="92"/>
+<text class="t-ttl" x="124" y="632">RDS MySQL</text>
+<text class="t-sub" x="124" y="648">db.t3.micro · single-AZ</text>
+<text class="t-sub" x="124" y="664">20 → 100 GB gp3, encrypted</text>
+<text class="t-sub" x="124" y="680">7-day automated backups</text>
+
+<rect class="box-m" x="340" y="610" width="198" height="92"/>
+<text class="t-chip" x="354" y="632">db-sg</text>
+<text class="t-sub" x="354" y="648">3306 ← nextcloud-sg</text>
+<text class="t-sub" x="354" y="664">no CIDR rule at all</text>
+<text class="t-ok" x="354" y="682">not publicly accessible</text>
+
+<rect class="box" x="88" y="746" width="472" height="54"/>
+<text class="t-chip" x="102" y="766">S3 gateway endpoint</text>
+<text class="t-sub" x="102" y="782">routed on priv-rt only — the instance sits in pub-a,</text>
+<text class="t-sub" x="102" y="795">so its S3 traffic leaves through the IGW instead</text>
+
+<rect class="box" x="716" y="200" width="380" height="96"/>
+<text class="t-ttl" x="732" y="222">S3 · primary object store</text>
+<text class="t-sub" x="732" y="240">onevoice-prod-nextcloud-bucket</text>
+<text class="t-sub" x="732" y="256">every object keyed urn:oid:&lt;fileid&gt;</text>
+<text class="t-sub" x="732" y="272">versioned · lifecycle to IA at 30d, expire 365d</text>
+<text class="t-ok" x="732" y="288">Object Lock GOVERNANCE · 10 years</text>
+
+<rect class="box" x="716" y="316" width="380" height="84"/>
+<text class="t-ttl" x="732" y="338">S3 · migration bucket</text>
+<text class="t-sub" x="732" y="356">mounted through Nextcloud External Storage</text>
+<text class="t-sub" x="732" y="372">addressed by real path, not by fileid</text>
+<text class="t-sub" x="732" y="390">SSE-AES256 · public access blocked</text>
+
+<rect class="box" x="716" y="420" width="380" height="84"/>
+<text class="t-ttl" x="732" y="442">SSM Parameter Store</text>
+<text class="t-sub" x="732" y="460">8 SecureStrings: db + admin passwords, tunnel</text>
+<text class="t-sub" x="732" y="476">token, MCP creds, GitHub PAT, migration keys</text>
+<text class="t-sub" x="732" y="494">three of them must pre-exist or first boot fails</text>
+
+<rect class="box" x="716" y="524" width="380" height="96"/>
+<text class="t-ttl" x="732" y="546">CloudWatch</text>
+<text class="t-sub" x="732" y="564">5 alarms: status check, CPU, CPU credits,</text>
+<text class="t-sub" x="732" y="580">memory, disk · nextcloud-ops dashboard</text>
+<text class="t-sub" x="732" y="598">memory and disk arrive under CWAgent,</text>
+<text class="t-sub" x="732" y="614">not AWS/EC2 — the agent is the only source</text>
+
+<line class="link" x1="906" y1="620" x2="906" y2="648" marker-end="url(#ah1)"/>
+<text class="t-lab" x="916" y="640">alarm</text>
+
+<rect class="box" x="716" y="650" width="380" height="72"/>
+<text class="t-ttl" x="732" y="672">SNS · ops-alerts</text>
+<text class="t-sub" x="732" y="690">one topic, alarm and OK actions both wired</text>
+<text class="t-sub" x="732" y="708">no paging, no escalation — email only</text>
+
+<line class="link" x1="906" y1="722" x2="906" y2="750" marker-end="url(#ah1)"/>
+<text class="t-lab" x="916" y="742">2 addresses</text>
+
+<rect class="box-2" x="716" y="752" width="380" height="56"/>
+<text class="t-chip" x="732" y="774">two ops mailboxes</text>
+<text class="t-sub" x="732" y="792">subscription confirmed by hand, once</text>
+
+<line class="link" x1="538" y1="400" x2="714" y2="248" marker-end="url(#ah1)"/>
+<text class="t-lab" x="627" y="316" text-anchor="middle">IAM role · no static keys</text>
+
+<line class="link" x1="538" y1="432" x2="714" y2="358" marker-end="url(#ah1)"/>
+<text class="t-lab" x="627" y="388" text-anchor="middle">IAM user access key</text>
+
+<line class="link" x1="538" y1="464" x2="714" y2="462" marker-end="url(#ah1)"/>
+<text class="t-lab" x="627" y="456" text-anchor="middle">8 SecureStrings · first boot</text>
+
+<line class="link" x1="538" y1="496" x2="714" y2="572" marker-end="url(#ah1)"/>
+<text class="t-lab" x="627" y="528" text-anchor="middle">metrics + nginx / app logs</text>
+
+<rect class="box-2" x="64" y="832" width="1032" height="52"/>
+<text class="t-frame" x="80" y="852">ACCOUNT-WIDE, NOT ON THE REQUEST PATH</text>
+<text class="t-sub" x="80" y="872">CloudTrail — multi-region, log-file validation, dedicated encrypted bucket   ·   AWS Budgets — $35/mo threshold, currently exceeded every month</text>
+</svg>

--- a/docs/diagrams/bluehost-architecture.svg
+++ b/docs/diagrams/bluehost-architecture.svg
@@ -1,0 +1,162 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -56 1160 856" role="img" aria-label="Bluehost VPS architecture: a single AlmaLinux 10 host running cloudflared, nginx, php-fpm, Nextcloud, MariaDB and Valkey, with a 50 GB local disk, a loopback-only Prometheus and Grafana stack, and outbound connections to Backblaze B2 and Amazon SES.">
+<title>OneVoice Nextcloud on a Bluehost VPS — AlmaLinux 10</title>
+<style>
+svg{
+  --ground:#F1F3F6; --surface:#FFFFFF; --surface-2:#E6EAF0;
+  --ink:#141920; --muted:#59636F; --line-strong:#A9B2BF;
+  --tunnel:#B0602A; --managed:#42517A; --risk:#A03D28; --ok:#346C4B;
+  --sans:ui-sans-serif,-apple-system,"Segoe UI",Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,SFMono-Regular,Consolas,"Liberation Mono",monospace;
+}
+@media (prefers-color-scheme:dark){
+  svg{
+    --ground:#0D1116; --surface:#161B22; --surface-2:#1F252E;
+    --ink:#E2E7EE; --muted:#8E99A8; --line-strong:#414B58;
+    --tunnel:#E39159; --managed:#93A2D4; --risk:#E0836B; --ok:#6EBB8C;
+  }
+}
+.bg{fill:var(--ground)}
+text{font-family:var(--mono);fill:var(--ink)}
+.h1{font-family:var(--sans);font-size:16px;font-weight:700;letter-spacing:-.01em}
+.h2{font-size:10.5px;fill:var(--muted);letter-spacing:.08em}
+.t-ttl{font-family:var(--sans);font-size:13px;font-weight:600}
+.t-sub{font-size:10.5px;fill:var(--muted)}
+.t-chip{font-size:10.5px}
+.t-frame{font-family:var(--sans);font-size:10.5px;font-weight:600;fill:var(--muted);letter-spacing:.12em}
+.t-lab{font-size:10px;fill:var(--muted)}
+.t-tun{font-size:10px;fill:var(--tunnel)}
+.t-risk{font-size:10.5px;fill:var(--risk)}
+.t-ok{font-size:10.5px;fill:var(--ok)}
+.box{fill:var(--surface);stroke:var(--line-strong);stroke-width:1}
+.box-2{fill:var(--surface-2);stroke:var(--line-strong);stroke-width:1}
+.box-m{fill:var(--surface);stroke:var(--managed);stroke-width:1.5}
+.frame{fill:none;stroke:var(--line-strong);stroke-width:1;stroke-dasharray:5 4}
+.frame-solid{fill:none;stroke:var(--line-strong);stroke-width:1.5}
+.chipbox{fill:var(--surface-2);stroke:none}
+.link{stroke:var(--line-strong);stroke-width:1.4;fill:none}
+.link-d{stroke:var(--line-strong);stroke-width:1.4;fill:none;stroke-dasharray:4 3}
+.tun{stroke:var(--tunnel);stroke-width:2;fill:none}
+marker path{fill:var(--line-strong)}
+marker.mt path{fill:var(--tunnel)}
+</style>
+<defs>
+  <marker id="ah2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z"/></marker>
+  <marker id="aht2" class="mt" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z"/></marker>
+</defs>
+
+<rect class="bg" x="0" y="-56" width="1160" height="856"/>
+<text class="h1" x="40" y="-30">OneVoice Nextcloud — Bluehost VPS deployment</text>
+<text class="h2" x="40" y="-12">CLOUD.KNOCH.DEV · ALMALINUX 10 · TWO IDEMPOTENT SHELL SCRIPTS, NO CONTROL PLANE</text>
+
+<rect class="box" x="40" y="28" width="130" height="56"/>
+<text class="t-ttl" x="56" y="52">People</text>
+<text class="t-sub" x="56" y="68">browser · desktop</text>
+
+<line class="link" x1="170" y1="56" x2="302" y2="56" marker-end="url(#ah2)"/>
+<text class="t-lab" x="236" y="46" text-anchor="middle">cloud.knoch.dev</text>
+
+<rect class="box" x="310" y="28" width="220" height="56"/>
+<text class="t-ttl" x="326" y="52">Cloudflare edge</text>
+<text class="t-sub" x="326" y="68">its own tunnel — not prod's token</text>
+
+<path class="tun" d="M 130 238 L 130 104 L 420 104 L 420 88" marker-end="url(#aht2)"/>
+<text class="t-tun" x="180" y="96">tunnel · outbound 443, nothing listens inbound</text>
+
+<rect class="frame-solid" x="40" y="124" width="800" height="624"/>
+<text class="t-frame" x="54" y="146">BLUEHOST VPS · ALMALINUX 10 · SELINUX ENFORCING</text>
+
+<rect class="box-m" x="200" y="166" width="616" height="44"/>
+<text class="t-chip" x="216" y="184">firewalld</text>
+<text class="t-sub" x="216" y="200">inbound: ssh, dhcpv6-client. 80/tcp stays closed (OPEN_HTTP_PORT=false)</text>
+
+<rect class="box" x="64" y="238" width="240" height="64"/>
+<text class="t-ttl" x="78" y="260">cloudflared</text>
+<text class="t-sub" x="78" y="277">dials out · systemd unit</text>
+<text class="t-sub" x="78" y="292">the only ingress path</text>
+
+<line class="link" x1="304" y1="270" x2="318" y2="270" marker-end="url(#ah2)"/>
+
+<rect class="box" x="320" y="238" width="240" height="64"/>
+<text class="t-ttl" x="334" y="260">nginx</text>
+<text class="t-sub" x="334" y="277">plain HTTP locally, so</text>
+<text class="t-sub" x="334" y="292">trusted_proxies + overwriteprotocol</text>
+
+<line class="link" x1="560" y1="270" x2="574" y2="270" marker-end="url(#ah2)"/>
+
+<rect class="box" x="576" y="238" width="240" height="64"/>
+<text class="t-ttl" x="590" y="260">php-fpm 8.3</text>
+<text class="t-sub" x="590" y="277">AppStream — EL10 has no</text>
+<text class="t-sub" x="590" y="292">DNF modules, so no 8.2 stream</text>
+
+<line class="link" x1="696" y1="302" x2="696" y2="332" marker-end="url(#ah2)"/>
+
+<rect class="box" x="64" y="334" width="752" height="72"/>
+<text class="t-ttl" x="78" y="356">Nextcloud 30</text>
+<text class="t-sub" x="78" y="374">the nginx server block is byte-identical to the AMI's — including both of its known gaps</text>
+<text class="t-ok" x="78" y="392">trashbin still works here: the object-store bug only bites when OBJECT_STORE=s3</text>
+
+<line class="link" x1="285" y1="406" x2="285" y2="432" marker-end="url(#ah2)"/>
+<text class="t-lab" x="293" y="424">3306</text>
+<line class="link" x1="651" y1="406" x2="651" y2="432" marker-end="url(#ah2)"/>
+<text class="t-lab" x="659" y="424">6379</text>
+<line class="link" x1="92" y1="406" x2="92" y2="532" marker-end="url(#ah2)"/>
+<text class="t-lab" x="100" y="474">data/</text>
+
+<rect class="box" x="120" y="434" width="330" height="72"/>
+<text class="t-ttl" x="134" y="456">MariaDB 10.11</text>
+<text class="t-sub" x="134" y="474">bound to 127.0.0.1 — never RDS</text>
+<text class="t-sub" x="134" y="492">READ-COMMITTED · ROW binlog · utf8mb4</text>
+
+<rect class="box" x="486" y="434" width="330" height="72"/>
+<text class="t-ttl" x="500" y="456">Valkey</text>
+<text class="t-sub" x="500" y="474">EL10 dropped Redis — wire-compatible fork</text>
+<text class="t-sub" x="500" y="492">distributed file locking + local cache</text>
+
+<rect class="box-2" x="64" y="534" width="752" height="84"/>
+<text class="t-ttl" x="78" y="556">50 GB local volume — this is primary storage</text>
+<text class="t-sub" x="78" y="574">base OS + packages + Nextcloud source ≈ 4–5 GB, leaving ~45 GB</text>
+<text class="t-risk" x="78" y="592">previews are what fill it: ~100–500 KB per file, cached locally even for files that live on B2</text>
+<text class="t-sub" x="78" y="610">chunked uploads also stage here first, so free disk caps the largest single upload</text>
+
+<rect class="frame" x="64" y="646" width="752" height="80"/>
+<text class="t-frame" x="80" y="668">MONITORING — ALL BOUND TO 127.0.0.1, GRAFANA REACHED ONLY VIA ITS TUNNEL HOSTNAME</text>
+<rect class="chipbox" x="88" y="684" width="200" height="30"/>
+<text class="t-chip" x="100" y="703">node_exporter :9100</text>
+<line class="link" x1="290" y1="699" x2="316" y2="699" marker-end="url(#ah2)"/>
+<rect class="chipbox" x="320" y="684" width="200" height="30"/>
+<text class="t-chip" x="332" y="703">Prometheus :9090</text>
+<line class="link" x1="522" y1="699" x2="548" y2="699" marker-end="url(#ah2)"/>
+<rect class="chipbox" x="552" y="684" width="200" height="30"/>
+<text class="t-chip" x="564" y="703">Grafana :3000</text>
+
+<rect class="box" x="880" y="180" width="240" height="84"/>
+<text class="t-ttl" x="894" y="202">onevoice.env</text>
+<text class="t-sub" x="894" y="220">/etc/onevoice/ · root:root 0600</text>
+<text class="t-sub" x="894" y="236">replaces SSM Parameter Store</text>
+<text class="t-sub" x="894" y="254">read by configure.sh, gitignored</text>
+<line class="link-d" x1="880" y1="222" x2="844" y2="222" marker-end="url(#ah2)"/>
+
+<rect class="box" x="880" y="340" width="240" height="100"/>
+<text class="t-ttl" x="894" y="362">Backblaze B2</text>
+<text class="t-sub" x="894" y="380">s3.us-east-005 · S3 API</text>
+<text class="t-sub" x="894" y="398">External Storage mount, so</text>
+<text class="t-sub" x="894" y="414">objects keep their real paths</text>
+<text class="t-risk" x="894" y="432">address it by NAME, not bucket ID</text>
+<line class="link" x1="816" y1="368" x2="874" y2="374" marker-end="url(#ah2)"/>
+<text class="t-lab" x="845" y="356" text-anchor="middle">S3 API</text>
+
+<rect class="box" x="880" y="470" width="240" height="76"/>
+<text class="t-ttl" x="894" y="492">Amazon SES</text>
+<text class="t-sub" x="894" y="510">noreply@knoch.dev</text>
+<text class="t-sub" x="894" y="526">production access granted —</text>
+<text class="t-sub" x="894" y="542">password resets actually work</text>
+<line class="link" x1="816" y1="392" x2="874" y2="500" marker-end="url(#ah2)"/>
+<text class="t-lab" x="824" y="452">SMTP 587</text>
+
+<rect class="box-2" x="880" y="576" width="240" height="100"/>
+<text class="t-frame" x="894" y="598">TURNED OFF HERE</text>
+<text class="t-sub" x="894" y="618">MCP server — needs an app</text>
+<text class="t-sub" x="894" y="634">password from a live instance</text>
+<text class="t-sub" x="894" y="654">maintenance timer — else two</text>
+<text class="t-sub" x="894" y="670">hosts file duplicate monthly PRs</text>
+</svg>

--- a/docs/diagrams/deployment-comparison.svg
+++ b/docs/diagrams/deployment-comparison.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -56 1080 656" role="img" aria-label="Comparison: a shared Nextcloud spine with six supporting roles, each filled by an AWS managed service on the left and a process on the Bluehost host on the right.">
+<title>AWS vs Bluehost — one application, two substrates</title>
+<style>
+svg{
+  --ground:#F1F3F6; --surface:#FFFFFF; --surface-2:#E6EAF0;
+  --ink:#141920; --muted:#59636F; --line-strong:#A9B2BF;
+  --tunnel:#B0602A; --managed:#42517A;
+  --sans:ui-sans-serif,-apple-system,"Segoe UI",Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,SFMono-Regular,Consolas,"Liberation Mono",monospace;
+}
+@media (prefers-color-scheme:dark){
+  svg{
+    --ground:#0D1116; --surface:#161B22; --surface-2:#1F252E;
+    --ink:#E2E7EE; --muted:#8E99A8; --line-strong:#414B58;
+    --tunnel:#E39159; --managed:#93A2D4;
+  }
+}
+.bg{fill:var(--ground)}
+text{font-family:var(--mono);fill:var(--ink)}
+.h1{font-family:var(--sans);font-size:16px;font-weight:700;letter-spacing:-.01em}
+.h2{font-size:10.5px;fill:var(--muted);letter-spacing:.08em}
+.t-ttl{font-family:var(--sans);font-size:13px;font-weight:600}
+.t-sub{font-size:10.5px;fill:var(--muted)}
+.t-chip{font-size:10.5px}
+.t-frame{font-family:var(--sans);font-size:10.5px;font-weight:600;fill:var(--muted);letter-spacing:.12em}
+.box{fill:var(--surface);stroke:var(--line-strong);stroke-width:1}
+.box-2{fill:var(--surface-2);stroke:var(--line-strong);stroke-width:1}
+.link{stroke:var(--line-strong);stroke-width:1.4;fill:none}
+marker path{fill:var(--line-strong)}
+</style>
+<defs>
+  <marker id="ah3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z"/></marker>
+</defs>
+
+<rect class="bg" x="0" y="-56" width="1080" height="656"/>
+<text class="h1" x="40" y="-30">One application, two substrates</text>
+<text class="h2" x="40" y="-12">THE APPLICATION LAYER IS IDENTICAL — SIX SUPPORTING ROLES CHANGE HANDS</text>
+
+<rect class="box" x="390" y="30" width="300" height="56"/>
+<text class="t-ttl" x="540" y="52" text-anchor="middle">Cloudflare Tunnel</text>
+<text class="t-sub" x="540" y="70" text-anchor="middle">the only front door on both hosts</text>
+<line class="link" x1="540" y1="86" x2="540" y2="118" marker-end="url(#ah3)"/>
+
+<text class="t-frame" x="40" y="106">AWS · ONEVOICE.KNOCH.DEV</text>
+<text class="t-frame" x="1040" y="106" text-anchor="end">BLUEHOST · CLOUD.KNOCH.DEV</text>
+
+<rect class="box-2" x="390" y="120" width="300" height="440"/>
+<text class="t-frame" x="540" y="146" text-anchor="middle">SHARED SPINE</text>
+<text class="t-sub" x="540" y="166" text-anchor="middle">Nextcloud 30 · same theming, same users</text>
+<text class="t-sub" x="540" y="182" text-anchor="middle">byte-identical nginx server block</text>
+<text class="t-sub" x="540" y="198" text-anchor="middle">php-fpm 8.2 / 8.3</text>
+
+<rect class="box" x="402" y="214" width="276" height="48"/>
+<text class="t-chip" x="540" y="243" text-anchor="middle">SECRETS</text>
+<line class="link" x1="370" y1="238" x2="400" y2="238"/>
+<line class="link" x1="680" y1="238" x2="710" y2="238"/>
+<rect class="box" x="40" y="214" width="330" height="48"/>
+<text class="t-chip" x="54" y="234">SSM Parameter Store</text>
+<text class="t-sub" x="54" y="250">8 SecureStrings, read at first boot</text>
+<rect class="box" x="710" y="214" width="330" height="48"/>
+<text class="t-chip" x="724" y="234">/etc/onevoice/onevoice.env</text>
+<text class="t-sub" x="724" y="250">one root-owned file, mode 0600</text>
+
+<rect class="box" x="402" y="272" width="276" height="48"/>
+<text class="t-chip" x="540" y="301" text-anchor="middle">DATABASE</text>
+<line class="link" x1="370" y1="296" x2="400" y2="296"/>
+<line class="link" x1="680" y1="296" x2="710" y2="296"/>
+<rect class="box" x="40" y="272" width="330" height="48"/>
+<text class="t-chip" x="54" y="292">RDS MySQL db.t3.micro</text>
+<text class="t-sub" x="54" y="308">private subnets, 7-day backups</text>
+<rect class="box" x="710" y="272" width="330" height="48"/>
+<text class="t-chip" x="724" y="292">MariaDB 10.11</text>
+<text class="t-sub" x="724" y="308">bound to 127.0.0.1, backups are yours</text>
+
+<rect class="box" x="402" y="330" width="276" height="48"/>
+<text class="t-chip" x="540" y="359" text-anchor="middle">PRIMARY STORAGE</text>
+<line class="link" x1="370" y1="354" x2="400" y2="354"/>
+<line class="link" x1="680" y1="354" x2="710" y2="354"/>
+<rect class="box" x="40" y="330" width="330" height="48"/>
+<text class="t-chip" x="54" y="350">S3, versioned</text>
+<text class="t-sub" x="54" y="366">Object Lock GOVERNANCE, 10 years</text>
+<rect class="box" x="710" y="330" width="330" height="48"/>
+<text class="t-chip" x="724" y="350">50 GB local disk</text>
+<text class="t-sub" x="724" y="366">B2 mounts alongside, by real path</text>
+
+<rect class="box" x="402" y="388" width="276" height="48"/>
+<text class="t-chip" x="540" y="417" text-anchor="middle">OBJECT-STORE AUTH</text>
+<line class="link" x1="370" y1="412" x2="400" y2="412"/>
+<line class="link" x1="680" y1="412" x2="710" y2="412"/>
+<rect class="box" x="40" y="388" width="330" height="48"/>
+<text class="t-chip" x="54" y="408">Instance role via IMDS</text>
+<text class="t-sub" x="54" y="424">no static keys on disk at all</text>
+<rect class="box" x="710" y="388" width="330" height="48"/>
+<text class="t-chip" x="724" y="408">Explicit access key</text>
+<text class="t-sub" x="724" y="424">mandatory — a VPS has no IMDS</text>
+
+<rect class="box" x="402" y="446" width="276" height="48"/>
+<text class="t-chip" x="540" y="475" text-anchor="middle">INBOUND FILTERING</text>
+<line class="link" x1="370" y1="470" x2="400" y2="470"/>
+<line class="link" x1="680" y1="470" x2="710" y2="470"/>
+<rect class="box" x="40" y="446" width="330" height="48"/>
+<text class="t-chip" x="54" y="466">EC2 security group</text>
+<text class="t-sub" x="54" y="482">a Terraform resource, outside the host</text>
+<rect class="box" x="710" y="446" width="330" height="48"/>
+<text class="t-chip" x="724" y="466">firewalld + SELinux enforcing</text>
+<text class="t-sub" x="724" y="482">a provisioning-script concern</text>
+
+<rect class="box" x="402" y="504" width="276" height="48"/>
+<text class="t-chip" x="540" y="533" text-anchor="middle">METRICS &amp; ALERTS</text>
+<line class="link" x1="370" y1="528" x2="400" y2="528"/>
+<line class="link" x1="680" y1="528" x2="710" y2="528"/>
+<rect class="box" x="40" y="504" width="330" height="48"/>
+<text class="t-chip" x="54" y="524">CloudWatch → SNS → email</text>
+<text class="t-sub" x="54" y="540">mem and disk need the agent running</text>
+<rect class="box" x="710" y="504" width="330" height="48"/>
+<text class="t-chip" x="724" y="524">Prometheus → Grafana</text>
+<text class="t-sub" x="724" y="540">loopback only — nothing pages anyone</text>
+</svg>


### PR DESCRIPTION
Adds diagrams of the two deployment targets and of what actually differs between them.

Closes #65

## What is here

Three hand-authored SVGs under `docs/diagrams/`, embedded with commentary in a new `docs/architecture.md`:

| File | Shows |
| --- | --- |
| `aws-architecture.svg` | VPC, subnets, EC2, RDS, both buckets, the managed control plane |
| `bluehost-architecture.svg` | The single AlmaLinux host, every service local, B2 and SES outbound |
| `deployment-comparison.svg` | The shared application spine and the six roles that swap |

Plus a one-line pointer to the new page from the root, `aws/` and `bluehost/` READMEs.

One commit, seven files. Branched off `chore/62-split-deployment-targets` because the diagrams edit `aws/README.md` and link to it; #62 has since merged into `dev`, so this diff is only the diagram work.

## Why SVG, not PDF or PNG

- Renders inline on GitHub, so `docs/architecture.md` shows the pictures on the page with no download step.
- Plain text, so a CIDR change diffs in review instead of landing as an opaque binary blob.
- Each file carries its own palette behind `prefers-color-scheme`, so it follows the reader light/dark setting.
- No build step, no toolchain, no export. Edit the coordinates and text directly.

## Two things the AWS diagram surfaced

Both are noted on the diagram and in `docs/architecture.md` as configuration facts, not filed as bugs:

- The **S3 gateway endpoint is routed on `priv-rt` only** (`aws/terraform/vpc.tf`), but the instance sits in `pub-a` on `main-rt` (`aws/terraform/compute.tf`) — so its S3 traffic leaves through the internet gateway rather than the endpoint.
- **`nextcloud-sg` opens 80/443 to `0.0.0.0/0`** while the tunnel is outbound-only, so those rules carry no traffic, though the instance does hold a public IP.

## Verification

All three files parse as valid XML (111 / 101 / 80 elements). Rendering was checked in both light and dark.