### PR TITLE
fix(bluehost): raise nginx fastcgi timeouts to match PHP (#68)

### DIFF
--- a/bluehost/provision.sh
+++ b/bluehost/provision.sh
@@ -407,6 +407,12 @@ sed -i "s/^pm.start_servers = .*/pm.start_servers = ${FPM_START}/"             /
 sed -i "s/^pm.min_spare_servers = .*/pm.min_spare_servers = ${FPM_MIN_SPARE}/" /etc/php-fpm.d/www.conf
 sed -i "s/^pm.max_spare_servers = .*/pm.max_spare_servers = ${FPM_MAX_SPARE}/" /etc/php-fpm.d/www.conf
 
+# Stock EL ships this commented out, which means 0 — FPM never force-kills a
+# request. Combined with a worker wedged on a slow B2 round trip, that ties up
+# a child indefinitely. Bound it at the same 3600s ceiling as
+# max_execution_time and nginx's fastcgi_read_timeout so all three agree.
+sed -i "s/^;request_terminate_timeout = 0$/request_terminate_timeout = 3600/" /etc/php-fpm.d/www.conf
+
 # php.ini tuning. The EC2 build set memory_limit at boot time inside
 # user-data.sh; it belongs here with the rest of the static config.
 cat > /etc/php.d/99-nextcloud.ini <<'EOF'
@@ -494,6 +500,17 @@ server {
         # depend on it (WebDAV under /remote.php/dav/..., OCS under
         # /ocs-provider/) then see an empty path.
         fastcgi_param PATH_INFO \$fastcgi_path_info;
+        # nginx defaults fastcgi_read_timeout to 60s, and PHP is already
+        # allowed 3600s by /etc/php.d/99-nextcloud.ini — so nginx, not PHP,
+        # was the binding limit. A MOVE/COPY on the B2 external mount is a
+        # per-object round trip and routinely runs past 60s; nginx returned
+        # 504 and dropped the upstream connection, killing the request while
+        # it still held an *exclusive* lock. Those locks then sat in Valkey
+        # for their full hour TTL, and every later operation on that node —
+        # including opening the sharing sidebar — failed with "Could not
+        # lock node". Match PHP's ceiling so the two agree.
+        fastcgi_read_timeout 3600;
+        fastcgi_send_timeout 3600;
         include fastcgi_params;
     }
 


### PR DESCRIPTION
﻿Closes #68
## Symptom

Opening the sharing options on a file returns "Could not lock node". Valkey held 8 orphaned lock keys, 4 of them `exclusive`, with up to an hour of TTL left.

## Cause

`provision.sh` never sets `fastcgi_read_timeout`, so nginx uses its default of **60 seconds**. PHP is already allowed 3600s by `/etc/php.d/99-nextcloud.ini`, so nginx â€” not PHP â€” was the binding limit.

A `MOVE`/`COPY` on the Backblaze B2 external mount is a per-object round trip and routinely runs past 60s. nginx returned 504 and dropped the upstream connection, killing the request while it still held an **exclusive** lock on the node. Those locks then sat in Valkey for their full hour TTL, and every later operation on that node â€” including the sharing sidebar, which locks the node to read shares â€” failed.

Observed:

```
15:23:45  MOVE .../Enoch-Dropbox/OneVoice/Joseph   504
15:29:09  MOVE .../Enoch-Dropbox/OneVoice/Dionne   504
```

## Fix

- `fastcgi_read_timeout 3600` and `fastcgi_send_timeout 3600` in the `\.php` location block, matching PHP's existing ceiling.
- `request_terminate_timeout = 3600` in the FPM pool. Stock EL leaves it commented out, meaning `0` â€” FPM never force-kills, so a worker wedged on a slow B2 round trip is tied up indefinitely.

Applied to the live host and verified: zero upstream timeouts since, sharing API returns 200, lock keys back to 0.

## Also affects AWS

`aws/packer/setup.sh` bakes the same nginx server block with no `fastcgi_read_timeout`, so `onevoice.knoch.dev` has the same latent bug on its migration mount. Not fixed here â€” needs its own change and a `packer build`.

## Scope note

This raises the ceiling; it does not make large moves fast. A folder move that exceeds 3600s still fails the same way, and the browser gives up long before that (observed as `499` in the access log). Bulk moves on a path-addressed external mount belong at the storage layer (rclone), not in a web request.
