### PR TITLE
release: nginx fastcgi timeout fix + CLAUDE.md (#68, #69)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# CLAUDE.md
+
+Self-hosted Nextcloud for the OneVoice gospel/choir group, replacing a shared personal Dropbox.
+
+Read this first for orientation and the rules that are easy to get wrong. The deep detail lives in the READMEs linked at the bottom — prefer them over re-deriving anything from the code.
+
+## Two deployment targets
+
+They are independent. Neither imports from the other. Always establish **which one** a question is about before acting — the answers usually differ.
+
+| | `aws/` | `bluehost/` |
+|---|---|---|
+| Live at | `onevoice.knoch.dev` | `cloud.knoch.dev` (`50.6.226.196`) |
+| Status | **Authoritative — holds the group's real data** | Functional, parallel, not yet carrying data |
+| Built by | Terraform + a Packer golden AMI | Two idempotent shell scripts |
+| Database | RDS MySQL, private subnets | MariaDB 10.11 on `127.0.0.1` |
+| Primary storage | S3, Object Lock 10y | 50 GB local disk |
+| Secrets from | SSM Parameter Store (8 SecureStrings) | `/etc/onevoice/onevoice.env` (root, 0600) |
+| PHP | 8.2 | 8.3 |
+
+Both run Nextcloud 30, the same theming and seed users, a byte-identical nginx server block, and Cloudflare Tunnel as the only front door. Diagrams: [`docs/architecture.md`](docs/architecture.md).
+
+## Layout
+
+```
+aws/terraform/      # main stack; state in S3
+aws/packer/         # golden AMI: nextcloud.pkr.hcl, setup.sh, files/
+infra/bootstrap/    # applied once, creates the state bucket the above depends on
+bluehost/           # provision.sh (no secrets) + configure.sh (all secrets) + bootstrap.sh
+docs/               # architecture, runbook, project plan, maintenance
+systems/            # generated monthly maintenance checklists
+```
+
+## Branching — these are enforced, not conventions
+
+- **`main` and `dev` are protected with `enforce_admins: true`.** Direct pushes fail even for the owner. Everything goes through a PR.
+- **Any PR touching a `.md` file must come from a `docs/` branch.** This catches changes that feel like `feat/` or `chore/` work — if a README line changes, the branch is `docs/`.
+- Branch format is `type/issue-number-slug`, so an issue must exist first. Create one with `gh issue create` rather than inventing a number.
+- Flow is feature → `dev` → `main`, merged with merge commits.
+- Before branching, **`git fetch`**. Local `origin/dev` and `origin/main` have been stale, which silently changes what a branch is based on.
+
+Full detail in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Reaching the hosts
+
+| Host | Command |
+|---|---|
+| Bluehost VPS | `ssh -i ~/.ssh/onevoice_bluehost root@50.6.226.196` |
+| AWS EC2 | key at `~/.ssh/ec2-nextcloud-key` (and `aws/terraform/keys/nextcloud-key`); get the IP from `terraform output server_ip` or `aws ec2 describe-instances --profile onevoice` |
+
+AWS SSH ingress is locked to `70.21.84.34/32`, so it only works from that address. The AWS CLI profile is `onevoice`.
+
+`onevoice.knoch.dev` and `cloud.knoch.dev` resolve to Cloudflare, not the hosts — you cannot SSH to them.
+
+## Running remote commands from this machine
+
+The shell here is **PowerShell on Windows**. It mangles quotes, `$`, and `\n` on the way into `ssh`, and the sandbox rejects some of those strings outright. Inline `ssh host 'script'` fails in ways that look like remote bugs but are local quoting.
+
+Send anything non-trivial as base64:
+
+```powershell
+$lines = @('echo one', 'echo two')
+$b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($lines -join "`n")))
+ssh -i "$env:USERPROFILE\.ssh\onevoice_bluehost" -o BatchMode=yes root@50.6.226.196 "echo $b64 | base64 -d | bash"
+```
+
+Avoid literal `\n` and `\$` inside the PowerShell string — both trip the sandbox guard.
+
+## Secret hygiene
+
+- **`occ files_external:list` prints the B2 access key and secret in cleartext** in its `Options` column. It redacts them in `Configuration` but not there. Never run it raw — filter it, or don't run it.
+- `aws/terraform/keys/` holds a real private key. It is gitignored; never copy that directory to a server.
+- `bluehost/onevoice.env` is gitignored and travels out of band. Only `.example` belongs in git.
+- Seed-user passwords land in `/root/onevoice-user-passwords.txt` (0600) on the VPS, SSM on AWS.
+
+## The scripts are the source of truth
+
+Fixing something by editing a config **on a host** is half a fix — the next provision run reverts it. Every host-side change must also land in the script that generates that file:
+
+- Bluehost: `bluehost/provision.sh` (OS, packages, nginx, php, systemd) or `bluehost/configure.sh` (database, install, theming, users)
+- AWS: `aws/packer/setup.sh` (bake time) or `aws/terraform/scripts/user-data.sh` (first boot)
+
+When a fix applies to both targets, say so explicitly — parity gaps between the two are a recurring source of bugs, and several fixes exist on one host only.
+
+## Known landmines
+
+- **Do not rename the Terraform backend keys.** `onevoice-storage/terraform.tfstate` and `infra/bootstrap/terraform.tfstate` are paths inside the state bucket, not repo paths. They look stale after the `aws/` rename; they are not. Rewriting either orphans the state and plans a full rebuild.
+- **`-replace` on the EC2 instance is not a clean install.** RDS survives, so `occ maintenance:install` collides with the existing database and `set -e` kills first-boot provisioning. Destroy and re-apply the whole stack instead.
+- **Never point the Bluehost clone at prod's S3 bucket or prod's tunnel token.** The first overwrites prod objects at `urn:oid:1,2,3…`; the second makes Cloudflare round-robin `onevoice.knoch.dev` between two hosts. Both are guarded in `configure.sh` and both defaults are safe.
+- **`user-data.sh` is a Terraform `templatefile()`.** Bash variables need `$${VAR}` or Terraform interpolates them.
+- **Trashbin is off on AWS** (S3 objectstore bug) — no undo anywhere on that instance. It works on Bluehost, which is on local disk.
+- **Moving files across storages loses their shares.** Cross-storage moves are copy-then-delete, so the fileid changes and `oc_share` rows go with the original. Same-storage renames keep shares.
+- **`terraform destroy` fails on the primary bucket** while it holds objects and now also because of Object Lock. Safe to re-run `apply`.
+
+## Verifying a host
+
+```bash
+# Bluehost
+sudo -u nginx php /var/www/nextcloud/occ status
+sudo -u nginx php /var/www/nextcloud/occ setupchecks
+systemctl status nginx php-fpm mariadb valkey cloudflared
+ss -tlnp | grep -E ':(3000|9090|9100)\b'   # expect 127.0.0.1 only
+firewall-cmd --list-services               # expect: dhcpv6-client ssh
+
+# stale Nextcloud file locks (symptom: "Could not lock node")
+valkey-cli -h 127.0.0.1 --scan --pattern '*lockfiles*' | while read -r k; do valkey-cli -h 127.0.0.1 del "$k"; done
+```
+
+## Where the real documentation is
+
+| Question | File |
+|---|---|
+| Why the project exists, design decisions, cost | [`README.md`](README.md) |
+| AWS operations, secrets, gotchas, monitoring | [`aws/README.md`](aws/README.md) |
+| Bluehost install, `onevoice.env`, EL10 platform facts | [`bluehost/README.md`](bluehost/README.md) |
+| Topology diagrams for both, and what differs | [`docs/architecture.md`](docs/architecture.md) |
+| Deploy procedure, workspace isolation | [`docs/deployment-runbook.md`](docs/deployment-runbook.md) |
+| Known-issues log, deferred decisions | [`docs/nextcloud-project-plan.md`](docs/nextcloud-project-plan.md) |
+| Branch, PR, label and milestone conventions | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+
+## Working notes
+
+- Both targets are applied manually and locally. There is no CI/CD.
+- The Bluehost scripts have never been run end to end against a live AlmaLinux 10 host; the running box was brought up incrementally.
+- Porting the group's data off EC2 was deferred until after the OneVoice group meeting on **2026-08-22**. Until then AWS stays authoritative and both run in parallel.

--- a/bluehost/provision.sh
+++ b/bluehost/provision.sh
@@ -407,6 +407,12 @@ sed -i "s/^pm.start_servers = .*/pm.start_servers = ${FPM_START}/"             /
 sed -i "s/^pm.min_spare_servers = .*/pm.min_spare_servers = ${FPM_MIN_SPARE}/" /etc/php-fpm.d/www.conf
 sed -i "s/^pm.max_spare_servers = .*/pm.max_spare_servers = ${FPM_MAX_SPARE}/" /etc/php-fpm.d/www.conf
 
+# Stock EL ships this commented out, which means 0 — FPM never force-kills a
+# request. Combined with a worker wedged on a slow B2 round trip, that ties up
+# a child indefinitely. Bound it at the same 3600s ceiling as
+# max_execution_time and nginx's fastcgi_read_timeout so all three agree.
+sed -i "s/^;request_terminate_timeout = 0$/request_terminate_timeout = 3600/" /etc/php-fpm.d/www.conf
+
 # php.ini tuning. The EC2 build set memory_limit at boot time inside
 # user-data.sh; it belongs here with the rest of the static config.
 cat > /etc/php.d/99-nextcloud.ini <<'EOF'
@@ -494,6 +500,17 @@ server {
         # depend on it (WebDAV under /remote.php/dav/..., OCS under
         # /ocs-provider/) then see an empty path.
         fastcgi_param PATH_INFO \$fastcgi_path_info;
+        # nginx defaults fastcgi_read_timeout to 60s, and PHP is already
+        # allowed 3600s by /etc/php.d/99-nextcloud.ini — so nginx, not PHP,
+        # was the binding limit. A MOVE/COPY on the B2 external mount is a
+        # per-object round trip and routinely runs past 60s; nginx returned
+        # 504 and dropped the upstream connection, killing the request while
+        # it still held an *exclusive* lock. Those locks then sat in Valkey
+        # for their full hour TTL, and every later operation on that node —
+        # including opening the sharing sidebar — failed with "Could not
+        # lock node". Match PHP's ceiling so the two agree.
+        fastcgi_read_timeout 3600;
+        fastcgi_send_timeout 3600;
         include fastcgi_params;
     }
 


### PR DESCRIPTION
Release `dev` into `main`. Two independent changes from the same session.

Closes #68
Closes #69

## #70 — nginx fastcgi timeout fix (`bluehost/provision.sh`)

Opening the sharing sidebar returned "Could not lock node". Root cause was a 60x mismatch between two timeouts:

- `provision.sh` never set `fastcgi_read_timeout`, so nginx used its default of **60s**.
- PHP was already allowed **3600s** by `/etc/php.d/99-nextcloud.ini`.

So nginx, not PHP, was the binding limit. A `MOVE` on the B2 external mount is a per-object round trip that routinely runs past 60s; nginx returned 504 and dropped the upstream connection, killing the request while it still held an **exclusive** lock. Those locks sat in Valkey for their full hour TTL, and every later operation on the node failed — including the sharing sidebar, which locks the node to read shares.

Sets `fastcgi_read_timeout` / `fastcgi_send_timeout` to 3600, and bounds `request_terminate_timeout` at 3600 in the FPM pool (stock EL leaves it at `0`, so a wedged worker is tied up indefinitely).

Applied to the live host and verified: sharing API returns 200, lock keys back to 0, no upstream timeouts since.

**Scope:** this raises the ceiling, it does not make large moves fast. Bulk moves on a path-addressed external mount belong at the storage layer (rclone), not in a web request.

**Also affects AWS:** `aws/packer/setup.sh` bakes the same nginx block with no `fastcgi_read_timeout`, so the EC2 host carries the same latent bug. Not fixed here — needs its own change and a `packer build`.

## #71 — `CLAUDE.md`

A short orientation file at the repo root: the two deployment targets side by side, the branch rules that are enforced rather than conventional, how to reach each host, the PowerShell-to-ssh quoting trap, secret hygiene, the "scripts are the source of truth" rule, and known landmines. Points at the READMEs rather than restating them.

No secrets — every credential reference is a pointer to where the value lives, never a value.
