### PR TITLE
docs: reflect AWS->Bluehost cutover, add EXTRA_TRUSTED_DOMAINS support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ They are independent. Neither imports from the other. Always establish **which o
 
 | | `aws/` | `bluehost/` |
 |---|---|---|
-| Live at | `onevoice.knoch.dev` | `cloud.knoch.dev` (`50.6.226.196`) |
-| Status | **Authoritative — holds the group's real data** | Functional, parallel, not yet carrying data |
+| Live at | *(decommissioned)* | `onevoice.knoch.dev` + `cloud.knoch.dev` (`50.6.226.196`) |
+| Status | Decommissioned 2026-08-23 — cut over to `bluehost/` | **Authoritative — holds the group's real data** |
 | Built by | Terraform + a Packer golden AMI | Two idempotent shell scripts |
 | Database | RDS MySQL, private subnets | MariaDB 10.11 on `127.0.0.1` |
 | Primary storage | S3, Object Lock 10y | 50 GB local disk |
@@ -121,5 +121,5 @@ valkey-cli -h 127.0.0.1 --scan --pattern '*lockfiles*' | while read -r k; do val
 ## Working notes
 
 - Both targets are applied manually and locally. There is no CI/CD.
-- The Bluehost scripts have never been run end to end against a live AlmaLinux 10 host; the running box was brought up incrementally.
-- Porting the group's data off EC2 was deferred until after the OneVoice group meeting on **2026-08-22**. Until then AWS stays authoritative and both run in parallel.
+- `bluehost/` is now the live, authoritative deployment — the group's real data was ported over and `onevoice.knoch.dev` was cut over to it on 2026-08-23. See issue #73.
+- `aws/` is being decommissioned (`terraform destroy`). Until that's done, its resources still exist but nothing points at them.

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,6 +1,8 @@
 # AWS deployment target
 
-Nextcloud on EC2 + RDS + S3, built with Terraform and a Packer golden AMI. Live at **`onevoice.knoch.dev`**, and currently the authoritative copy of the group's data.
+Nextcloud on EC2 + RDS + S3, built with Terraform and a Packer golden AMI.
+
+**Decommissioned 2026-08-23.** The group's data was ported to [`bluehost/`](../bluehost/README.md), which now serves `onevoice.knoch.dev` and is authoritative. This stack is being torn down (`terraform destroy`) — see issue #73. What follows describes the deployment as it operated up to that point, kept for reference until the teardown is complete.
 
 For *why* this shape — S3 over EBS, a single EC2 instance over containers/K8s/serverless, rclone for the Dropbox migration — see the [root README](../README.md#design-decisions). This document is the operational one.
 

--- a/bluehost/README.md
+++ b/bluehost/README.md
@@ -43,8 +43,8 @@ the tunnel token, SMTP and object-storage keys). Shape of it:
 
 | Setting | Value | Why |
 | --- | --- | --- |
-| Access | `https://cloud.knoch.dev` via Cloudflare Tunnel | TLS terminates at the edge; nginx serves plain HTTP locally, so `trusted_proxies` and `overwriteprotocol=https` are set. |
-| Trusted domains | `cloud.knoch.dev` + the raw IP | `configure.sh` deletes and rewrites the array, so this is the exact list. |
+| Access | `https://onevoice.knoch.dev` (canonical) + `https://cloud.knoch.dev`, both via Cloudflare Tunnel | TLS terminates at the edge; nginx serves plain HTTP locally, so `trusted_proxies` and `overwriteprotocol=https` are set. Both hostnames route to this box's tunnel as separate Public Hostnames. |
+| Trusted domains | `onevoice.knoch.dev` (`overwrite.cli.url`) + `cloud.knoch.dev` + the raw IP | `DOMAIN_NAME` + `EXTRA_TRUSTED_DOMAINS` in `onevoice.env`; `configure.sh` deletes and rewrites the array, so this is the exact list. |
 | `OPEN_HTTP_PORT` | `false` | The tunnel is outbound-only. **SSH is the only externally reachable port.** |
 | Database | local MariaDB, bound to `127.0.0.1` | Not RDS — see below. |
 | Primary storage | local disk | Not the B2 bucket — see below. |
@@ -53,9 +53,10 @@ the tunnel token, SMTP and object-storage keys). Shape of it:
 | Outbound email | Amazon SES, `noreply@knoch.dev` | Production access granted; password resets work. |
 | MCP / maintenance timer | off | MCP needs an app password minted from a running instance; the maintenance timer is off so two hosts don't file duplicate monthly PRs. |
 
-**Status: functional, not yet carrying the group's data.** Porting from the EC2
-instance is deferred until after the OneVoice group meeting on **2026-08-22**.
-Until then the AWS deployment remains authoritative and both run in parallel.
+**Status: authoritative — carrying the group's real data.** Ported from the EC2
+instance and cut over on **2026-08-23**: `onevoice.knoch.dev`'s Cloudflare Tunnel
+public hostname now points here instead of AWS. See issue #73. The AWS
+deployment is being decommissioned.
 
 **Why the database is local and not RDS.** Your RDS instance holds the
 *production* database. Pointing this box at it would not produce a clone — it

--- a/bluehost/configure.sh
+++ b/bluehost/configure.sh
@@ -367,6 +367,12 @@ log "Setting trusted domains and proxy trust"
 TRUSTED_DOMAINS=()
 if [[ -n "${SERVER_IP:-}" ]];   then TRUSTED_DOMAINS+=("$SERVER_IP");   fi
 if [[ -n "${DOMAIN_NAME:-}" ]]; then TRUSTED_DOMAINS+=("$DOMAIN_NAME"); fi
+# Additional hostnames that should be accepted but aren't the canonical
+# BASE_URL — e.g. this box answering for more than one public hostname during
+# a migration. Space-separated.
+if [[ -n "${EXTRA_TRUSTED_DOMAINS:-}" ]]; then
+  for d in $EXTRA_TRUSTED_DOMAINS; do TRUSTED_DOMAINS+=("$d"); done
+fi
 
 # `|| true`: deleting a key that was never set is a no-op we do not want to
 # abort on, and trusted_domains is absent on a brand new install.

--- a/bluehost/onevoice.env.example
+++ b/bluehost/onevoice.env.example
@@ -42,6 +42,11 @@ SERVER_IP=""
 # configure.sh deletes and rewrites the array, so whichever of these you set is
 # exactly what Nextcloud will accept. Set only SERVER_IP for IP-only access.
 #
+# Additional hostnames this box should accept but that are NOT the canonical
+# URL (DOMAIN_NAME is used for overwrite.cli.url / email links / share links).
+# Space-separated. Example: running two public hostnames during a migration.
+EXTRA_TRUSTED_DOMAINS=""
+#
 # These also decide how Nextcloud describes itself to browsers:
 #   tunnel + domain -> https://DOMAIN_NAME, trusted_proxies + overwriteprotocol set
 #   IP only         -> http://SERVER_IP,   both overrides CLEARED

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,15 @@ Latest tagged release: `v1.3.0` (2026-07-18)
 
 ### Completed
 
+#### AWS → Bluehost cutover complete — `onevoice.knoch.dev` now serves from Bluehost
+- Migrated the group's real files from EC2/S3 to the Bluehost VPS via `rclone` (S3 → Backblaze B2), mounted read-mostly as External Storage (`ENABLE_MIGRATION_MOUNT`), then reshared by hand from the admin account to match existing AWS shares 1:1.
+- Reassigned the `onevoice.knoch.dev` Cloudflare Tunnel public hostname from the EC2 tunnel to the Bluehost tunnel — a DNS-level cutover, no downtime. `cloud.knoch.dev` stays live on the same box as a secondary trusted domain.
+- Added `EXTRA_TRUSTED_DOMAINS` support to `configure.sh`/`onevoice.env` so a box can answer for more than one public hostname without a future `configure.sh` run reverting `trusted_domains` back down to one. `overwrite.cli.url` (used for password-reset/share links) now points at `onevoice.knoch.dev` as the canonical URL.
+- **Why:** deferred until after the OneVoice group meeting on 2026-08-22 — that gate has passed.
+- **Password reset required, by design:** Bluehost's seed-user passwords don't match AWS's, so each member's first login fails and falls through to "Forgot password" (SES delivery verified beforehand). Accepted tradeoff for a same-day, no-announcement cutover — data, shares, and theming carried over silently.
+- **Status:** live. AWS (EC2 + RDS + S3) is being decommissioned now that Bluehost is confirmed authoritative.
+- Tracked as #73.
+
 #### Cloudflare Tunnel + custom domain
 - Deployed `cloudflared` on the EC2 instance, tunneling inbound traffic instead of relying on the instance's public IP with 80/443 open directly.
 - Registered a personal `.dev` domain and created a subdomain for Nextcloud, currently `onevoice.knoch.dev`, routed through the tunnel over HTTPS.


### PR DESCRIPTION
## What

Documents the AWS → Bluehost cutover that already happened live, and makes the `configure.sh` change that made it possible.

- `CLAUDE.md`, `aws/README.md`, `bluehost/README.md`, `changelog.md` — flip status from "AWS authoritative" to "Bluehost authoritative," record the cutover date and mechanism.
- `bluehost/configure.sh` + `onevoice.env.example` — new `EXTRA_TRUSTED_DOMAINS` setting, so a box can answer for more than one public hostname (`onevoice.knoch.dev` + `cloud.knoch.dev`) without a future re-run of `configure.sh` reverting `trusted_domains` back down to one.

## Why

`onevoice.knoch.dev`'s Cloudflare Tunnel public hostname was reassigned from the EC2 tunnel to the Bluehost tunnel — DNS-level, no downtime. The group's real files were already ported over via rclone (S3 → B2) and reshared to match AWS. This PR is the "scripts/docs are the source of truth" half of that work landing in git.

## Not in this PR

AWS teardown (`terraform destroy`) — tracked separately in #73, still in progress.

Refs #73
