### PR TITLE
fix: raise upload body-size limits to 2G for large desktop uploads

### DIFF
--- a/bluehost/provision.sh
+++ b/bluehost/provision.sh
@@ -415,10 +415,20 @@ sed -i "s/^;request_terminate_timeout = 0$/request_terminate_timeout = 3600/" /e
 
 # php.ini tuning. The EC2 build set memory_limit at boot time inside
 # user-data.sh; it belongs here with the rest of the static config.
+#
+# upload_max_filesize/post_max_size at 2G, not memory_limit: PHP streams a
+# WebDAV PUT body straight through rather than buffering it in memory, so
+# raising these doesn't cost RAM. 2G covers the desktop client's adaptive
+# chunk size (it grows chunks on fast connections/large files) without
+# matching the full file size — chunked uploads assemble server-side, so a
+# 30GB file only ever needs one chunk's worth in flight at a time. See #78:
+# at 512M a large upload's oversized chunk got its connection hard-closed by
+# nginx instead of a clean error, and the desktop client just reported
+# "could not connect to the server".
 cat > /etc/php.d/99-nextcloud.ini <<'EOF'
 memory_limit = 512M
-upload_max_filesize = 512M
-post_max_size = 512M
+upload_max_filesize = 2G
+post_max_size = 2G
 max_execution_time = 3600
 max_input_time = 3600
 output_buffering = 0
@@ -459,7 +469,9 @@ server {
     server_name _;
     root ${NEXTCLOUD_PATH};
 
-    client_max_body_size 512M;
+    # 2G, matched to php.ini's upload_max_filesize/post_max_size above — not
+    # to any specific file size. See #78.
+    client_max_body_size 2G;
     fastcgi_buffers 64 4K;
 
     # No security headers are set here on purpose. Nextcloud emits its own


### PR DESCRIPTION
## Summary
- Traced a team member's "could not connect to the server" errors uploading a 30GB video via the macOS desktop client to nginx's `client_max_body_size` and php.ini's `upload_max_filesize`/`post_max_size` all being `512M`. The desktop client's chunked upload grows its chunk size adaptively for large files/fast connections, and once a chunk crossed 512M, nginx hard-closed the connection rather than returning a clean HTTP error — the client just reported a generic connection failure.
- Confirmed live: the chunked-upload directory Nextcloud created for this exact file existed but was completely empty — the first oversized chunk was being rejected before any data landed.
- Raises the three limits to `2G`. This is sized to comfortably cover the client's chunk size, not the full file — chunked uploads assemble server-side from independent chunk requests, so nginx's per-request limit never needs to match total file size.
- Already applied live on the Bluehost VPS (config edited + nginx/php-fpm reloaded, verified via a real PHP-FPM request that the new value is in effect) to unblock the upload in progress. This PR lands the same values in `provision.sh` so a future re-provision doesn't regress it.

## Disk-space note (not addressed here)
The VPS has ~33GB free on a 49GB disk, and Nextcloud's chunking writes chunks to local disk before assembling and pushing to B2 — a 30GB upload needs close to 30GB of local headroom mid-transfer. Not a code fix, just something to watch if very large uploads become routine. Tracked in #78.

Closes #78.

## Test plan
- [x] `bash -n bluehost/provision.sh` — syntax clean.
- [x] Applied the equivalent change live on the Bluehost VPS: `nginx -t` passed, `systemctl reload nginx php-fpm` succeeded, confirmed `2G` via a live PHP-FPM request (not just the config file).
- [ ] Have the team member retry the 30GB upload and confirm it completes (disk headroom permitting).