### PR TITLE
fix: clean up stale WebDAV chunked-upload staging directories

### DIFF
--- a/bluehost/files/nextcloud-chunk-cleanup.service
+++ b/bluehost/files/nextcloud-chunk-cleanup.service
@@ -1,0 +1,11 @@
+# /etc/systemd/system/nextcloud-chunk-cleanup.service
+[Unit]
+Description=Remove stale Nextcloud chunked-upload staging directories
+
+[Service]
+Type=oneshot
+User=nginx
+EnvironmentFile=__ENV_FILE__
+ExecStart=/usr/local/sbin/nextcloud-chunk-cleanup.sh
+StandardOutput=journal
+StandardError=journal

--- a/bluehost/files/nextcloud-chunk-cleanup.sh
+++ b/bluehost/files/nextcloud-chunk-cleanup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# nextcloud-chunk-cleanup.sh — removes stale WebDAV chunked-upload staging
+# directories.
+#
+# When a chunked upload's final assembly (MOVE) fails — e.g. the destination
+# filename contains a character Nextcloud forbids, as happened with Logic Pro
+# autosave files containing ":" — the chunks already written to
+# data/<user>/uploads/<token>/ are never cleaned up, and a client that keeps
+# retrying the same doomed upload keeps adding to them indefinitely. This
+# filled the disk to 100% on 2026-08-23 (issue #80). Nextcloud's own
+# stale-upload background job never catches this case because each retry
+# refreshes the folder's mtime, so it never looks stale to that job.
+#
+# Deletes any uploads/<token>/ directory whose mtime is older than
+# STALE_HOURS — a retrying client just starts the token over from scratch, so
+# this is safe to run unconditionally.
+set -euo pipefail
+
+DATA_DIR="${NEXTCLOUD_DATA_DIR:-/var/www/nextcloud/data}"
+STALE_HOURS="${CHUNK_CLEANUP_STALE_HOURS:-3}"
+STALE_MINUTES=$((STALE_HOURS * 60))
+
+find "$DATA_DIR" -mindepth 3 -maxdepth 3 -type d -path '*/uploads/*' -mmin +"$STALE_MINUTES" -print0 |
+while IFS= read -r -d '' token_dir; do
+  echo "Removing stale chunk upload: $token_dir"
+  rm -rf -- "$token_dir"
+done

--- a/bluehost/files/nextcloud-chunk-cleanup.timer
+++ b/bluehost/files/nextcloud-chunk-cleanup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Nextcloud stale chunked-upload cleanup hourly
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=1h
+Persistent=true
+Unit=nextcloud-chunk-cleanup.service
+
+[Install]
+WantedBy=timers.target

--- a/bluehost/onevoice.env.example
+++ b/bluehost/onevoice.env.example
@@ -98,6 +98,10 @@ OBJECT_STORE="local"
 
 NEXTCLOUD_DATA_DIR="/var/www/nextcloud/data"   # used when OBJECT_STORE=local
 
+# Hours a WebDAV chunked-upload staging dir (data/<user>/uploads/<token>/) can
+# sit untouched before nextcloud-chunk-cleanup.timer deletes it. See issue #80.
+CHUNK_CLEANUP_STALE_HOURS="3"
+
 S3_BUCKET=""                    # REQUIRED when OBJECT_STORE=s3 — a NEW bucket
 S3_REGION="us-east-1"
 S3_ACCESS_KEY=""                # REQUIRED when OBJECT_STORE=s3

--- a/bluehost/provision.sh
+++ b/bluehost/provision.sh
@@ -40,6 +40,7 @@ DB_MODE="${DB_MODE:-local}"
 OBJECT_STORE="${OBJECT_STORE:-local}"
 ENABLE_REDIS="${ENABLE_REDIS:-true}"
 ENABLE_CRON_TIMER="${ENABLE_CRON_TIMER:-true}"
+ENABLE_CHUNK_CLEANUP_TIMER="${ENABLE_CHUNK_CLEANUP_TIMER:-true}"
 ENABLE_MCP="${ENABLE_MCP:-true}"
 ENABLE_CLOUDFLARED="${ENABLE_CLOUDFLARED:-true}"
 ENABLE_MAINTENANCE_TIMER="${ENABLE_MAINTENANCE_TIMER:-false}"
@@ -889,6 +890,12 @@ install -d -o "$SERVICE_USER" -g "$SERVICE_USER" -m 0755 "${SERVICE_HOME}/script
 install -o "$SERVICE_USER" -g "$SERVICE_USER" -m 0700 \
   "$SCRIPT_DIR/files/nextcloud-maintenance-check.sh" \
   "${SERVICE_HOME}/scripts/nextcloud-maintenance-check.sh"
+# Lives in /usr/local/sbin, not ${SERVICE_HOME}/scripts like the maintenance
+# script above: this one runs as nginx, and ${SERVICE_HOME} (/home/onevoice)
+# is mode 0700 — nginx can't even traverse into it to reach the script.
+install -o root -g root -m 0755 \
+  "$SCRIPT_DIR/files/nextcloud-chunk-cleanup.sh" \
+  /usr/local/sbin/nextcloud-chunk-cleanup.sh
 
 # The unit files ship with placeholders instead of a hardcoded /home/ec2-user,
 # so the service account is configurable rather than baked into the AMI.
@@ -926,6 +933,11 @@ if [[ "$ENABLE_CRON_TIMER" == "true" ]]; then
   render_unit "$SCRIPT_DIR/files/nextcloud-cron.timer"   /etc/systemd/system/nextcloud-cron.timer
 fi
 
+if [[ "$ENABLE_CHUNK_CLEANUP_TIMER" == "true" ]]; then
+  render_unit "$SCRIPT_DIR/files/nextcloud-chunk-cleanup.service" /etc/systemd/system/nextcloud-chunk-cleanup.service
+  render_unit "$SCRIPT_DIR/files/nextcloud-chunk-cleanup.timer"   /etc/systemd/system/nextcloud-chunk-cleanup.timer
+fi
+
 systemctl daemon-reload
 
 log "Enabling services"
@@ -953,6 +965,9 @@ if [[ "$ENABLE_MAINTENANCE_TIMER" == "true" ]]; then
 fi
 if [[ "$ENABLE_CRON_TIMER" == "true" ]]; then
   systemctl enable nextcloud-cron.timer
+fi
+if [[ "$ENABLE_CHUNK_CLEANUP_TIMER" == "true" ]]; then
+  systemctl enable nextcloud-chunk-cleanup.timer
 fi
 if [[ "${ENABLE_MONITORING:-false}" == "true" ]]; then
   systemctl enable --now node_exporter


### PR DESCRIPTION
Closes #80

See issue for the full incident writeup. Adds an hourly systemd timer (
extcloud-chunk-cleanup.timer) that removes any data/<user>/uploads/<token>/ chunk-upload staging directory untouched for 3+ hours (CHUNK_CLEANUP_STALE_HOURS, configurable in onevoice.env).

Already applied to and verified running on the live Bluehost host (cloud.knoch.dev) - this PR brings the script in line with what's now running, per the repo rule that provision.sh is the source of truth.

Doc update for luehost/README.md is split into a separate docs/ branch per the branch-protection rule on .md-touching PRs.