### PR TITLE
fix: nightly restic backup of Nextcloud data + database to B2

### DIFF
--- a/bluehost/files/nextcloud-backup.service
+++ b/bluehost/files/nextcloud-backup.service
@@ -1,0 +1,13 @@
+# /etc/systemd/system/nextcloud-backup.service
+[Unit]
+Description=Nightly restic backup of Nextcloud data + database to Backblaze B2
+After=network-online.target mariadb.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+EnvironmentFile=__ENV_FILE__
+ExecStart=/usr/local/sbin/nextcloud-backup.sh
+StandardOutput=journal
+StandardError=journal

--- a/bluehost/files/nextcloud-backup.sh
+++ b/bluehost/files/nextcloud-backup.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# nextcloud-backup.sh — nightly restic backup to a dedicated Backblaze B2
+# bucket (issue #80's storage-off-local-disk followup).
+#
+# Backs up:
+#   - NEXTCLOUD_DATA_DIR (all real user files)
+#   - a mysqldump of the Nextcloud database
+#   - config/config.php
+#
+# Deliberately a SEPARATE bucket from both the primary storage bucket and the
+# existing "OneVoice Storage" migration mount — a backup living next to what
+# it protects defeats the point.
+set -euo pipefail
+
+NC_PATH="${NEXTCLOUD_PATH:-/var/www/nextcloud}"
+DATA_DIR="${NEXTCLOUD_DATA_DIR:-${NC_PATH}/data}"
+DB_HOST="${DB_HOST:-127.0.0.1}"
+DB_NAME="${DB_NAME:-nextcloud}"
+DB_USER="${DB_USER:-nextcloud}"
+
+KEEP_DAILY="${BACKUP_KEEP_DAILY:-7}"
+KEEP_WEEKLY="${BACKUP_KEEP_WEEKLY:-4}"
+KEEP_MONTHLY="${BACKUP_KEEP_MONTHLY:-6}"
+
+for v in BACKUP_B2_BUCKET BACKUP_B2_KEY_ID BACKUP_B2_APPLICATION_KEY BACKUP_RESTIC_PASSWORD DB_PASSWORD; do
+  if [ -z "${!v:-}" ]; then
+    echo "FATAL: $v is not set in the environment file. Aborting backup." >&2
+    exit 1
+  fi
+done
+
+export RESTIC_REPOSITORY="b2:${BACKUP_B2_BUCKET}:nextcloud"
+export B2_ACCOUNT_ID="$BACKUP_B2_KEY_ID"
+export B2_ACCOUNT_KEY="$BACKUP_B2_APPLICATION_KEY"
+export RESTIC_PASSWORD="$BACKUP_RESTIC_PASSWORD"
+
+WORKDIR=$(mktemp -d)
+MAINTENANCE_ON=0
+cleanup() {
+  if [ "$MAINTENANCE_ON" = "1" ]; then
+    sudo -u nginx php "${NC_PATH}/occ" maintenance:mode --off || true
+  fi
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+if ! restic snapshots >/dev/null 2>&1; then
+  echo "==> No existing repository found at ${RESTIC_REPOSITORY}, initializing"
+  restic init
+fi
+
+echo "==> Enabling maintenance mode for a consistent DB dump"
+sudo -u nginx php "${NC_PATH}/occ" maintenance:mode --on
+MAINTENANCE_ON=1
+
+echo "==> Dumping database"
+mysqldump --single-transaction -h "$DB_HOST" -u "$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" \
+  > "${WORKDIR}/nextcloud-db.sql"
+
+echo "==> Disabling maintenance mode"
+sudo -u nginx php "${NC_PATH}/occ" maintenance:mode --off
+MAINTENANCE_ON=0
+
+echo "==> Running restic backup"
+restic backup \
+  "$DATA_DIR" \
+  "${NC_PATH}/config/config.php" \
+  "${WORKDIR}/nextcloud-db.sql" \
+  --tag nextcloud-nightly
+
+echo "==> Applying retention (daily=${KEEP_DAILY} weekly=${KEEP_WEEKLY} monthly=${KEEP_MONTHLY})"
+restic forget --keep-daily "$KEEP_DAILY" --keep-weekly "$KEEP_WEEKLY" --keep-monthly "$KEEP_MONTHLY" --prune
+
+echo "==> Done"

--- a/bluehost/files/nextcloud-backup.timer
+++ b/bluehost/files/nextcloud-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Nextcloud backup nightly
+
+[Timer]
+OnCalendar=*-*-* 08:00:00 UTC
+Persistent=true
+Unit=nextcloud-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/bluehost/onevoice.env.example
+++ b/bluehost/onevoice.env.example
@@ -102,6 +102,30 @@ NEXTCLOUD_DATA_DIR="/var/www/nextcloud/data"   # used when OBJECT_STORE=local
 # sit untouched before nextcloud-chunk-cleanup.timer deletes it. See issue #80.
 CHUNK_CLEANUP_STALE_HOURS="3"
 
+# ---------------------------------------------------------------------------
+# Backups (nextcloud-backup.timer, nightly restic run — see issue #83)
+# ---------------------------------------------------------------------------
+#  ############################################################
+#  #  USE A DIFFERENT BUCKET THAN EVERYTHING ELSE              #
+#  ############################################################
+#  A backup living in the same bucket as what it protects defeats the point.
+#  Create a NEW, dedicated, private B2 bucket for this — do not reuse the
+#  "OneVoice Storage" migration bucket or any future OBJECT_STORE=s3 bucket.
+#  ############################################################
+BACKUP_B2_BUCKET=""              # REQUIRED — dedicated backup bucket name
+BACKUP_B2_KEY_ID=""              # REQUIRED — applicationKeyId scoped to that bucket
+BACKUP_B2_APPLICATION_KEY=""     # REQUIRED — applicationKey secret
+
+# Encrypts the restic repository. Generate with `openssl rand -base64 32`.
+# Store a copy OFF this server (password manager, etc) — if this server's
+# disk is lost along with this file, the backups it protects become
+# permanently unreadable. Restic has no recovery backdoor.
+BACKUP_RESTIC_PASSWORD=""        # REQUIRED
+
+BACKUP_KEEP_DAILY="7"
+BACKUP_KEEP_WEEKLY="4"
+BACKUP_KEEP_MONTHLY="6"
+
 S3_BUCKET=""                    # REQUIRED when OBJECT_STORE=s3 — a NEW bucket
 S3_REGION="us-east-1"
 S3_ACCESS_KEY=""                # REQUIRED when OBJECT_STORE=s3

--- a/bluehost/provision.sh
+++ b/bluehost/provision.sh
@@ -41,6 +41,7 @@ OBJECT_STORE="${OBJECT_STORE:-local}"
 ENABLE_REDIS="${ENABLE_REDIS:-true}"
 ENABLE_CRON_TIMER="${ENABLE_CRON_TIMER:-true}"
 ENABLE_CHUNK_CLEANUP_TIMER="${ENABLE_CHUNK_CLEANUP_TIMER:-true}"
+ENABLE_BACKUP_TIMER="${ENABLE_BACKUP_TIMER:-true}"
 ENABLE_MCP="${ENABLE_MCP:-true}"
 ENABLE_CLOUDFLARED="${ENABLE_CLOUDFLARED:-true}"
 ENABLE_MAINTENANCE_TIMER="${ENABLE_MAINTENANCE_TIMER:-false}"
@@ -909,6 +910,13 @@ install -o root -g root -m 0755 \
   "$SCRIPT_DIR/files/nextcloud-chunk-cleanup.sh" \
   /usr/local/sbin/nextcloud-chunk-cleanup.sh
 
+if [[ "$ENABLE_BACKUP_TIMER" == "true" ]]; then
+  dnf install -y restic
+  install -o root -g root -m 0755 \
+    "$SCRIPT_DIR/files/nextcloud-backup.sh" \
+    /usr/local/sbin/nextcloud-backup.sh
+fi
+
 # The unit files ship with placeholders instead of a hardcoded /home/ec2-user,
 # so the service account is configurable rather than baked into the AMI.
 render_unit() {
@@ -950,6 +958,11 @@ if [[ "$ENABLE_CHUNK_CLEANUP_TIMER" == "true" ]]; then
   render_unit "$SCRIPT_DIR/files/nextcloud-chunk-cleanup.timer"   /etc/systemd/system/nextcloud-chunk-cleanup.timer
 fi
 
+if [[ "$ENABLE_BACKUP_TIMER" == "true" ]]; then
+  render_unit "$SCRIPT_DIR/files/nextcloud-backup.service" /etc/systemd/system/nextcloud-backup.service
+  render_unit "$SCRIPT_DIR/files/nextcloud-backup.timer"   /etc/systemd/system/nextcloud-backup.timer
+fi
+
 systemctl daemon-reload
 
 log "Enabling services"
@@ -980,6 +993,9 @@ if [[ "$ENABLE_CRON_TIMER" == "true" ]]; then
 fi
 if [[ "$ENABLE_CHUNK_CLEANUP_TIMER" == "true" ]]; then
   systemctl enable nextcloud-chunk-cleanup.timer
+fi
+if [[ "$ENABLE_BACKUP_TIMER" == "true" ]]; then
+  systemctl enable nextcloud-backup.timer
 fi
 if [[ "${ENABLE_MONITORING:-false}" == "true" ]]; then
   systemctl enable --now node_exporter


### PR DESCRIPTION
## Problem
The Bluehost VPS (the authoritative production host, per issue #73) has no backup of any kind — no cron job, no restic/borg/rclone/duplicity, nothing. If the disk fails or a destructive command runs, the group's real data (choir recordings, Logic projects, etc.) is unrecoverable.

Surfaced while investigating #80 (disk-full incident) and a follow-up request to eventually move primary storage off local disk onto Backblaze B2 — agreed to sequence backups first, since migrating live production storage with zero backup safety net is too risky.

## Fix
Nightly restic backup to a NEW, dedicated B2 bucket (separate from both the existing "OneVoice Storage" migration mount and any future primary-storage bucket). Backs up NEXTCLOUD_DATA_DIR, a mysqldump of the database, and config/config.php. Retention: 7 daily / 4 weekly / 6 monthly.

New onevoice.env vars (already set on the live host): BACKUP_B2_BUCKET, BACKUP_B2_KEY_ID, BACKUP_B2_APPLICATION_KEY, BACKUP_RESTIC_PASSWORD.

## Scope
Bluehost only.
