### PR TITLE
fix: pin PHP session/opcache/wsdlcache dirs to nginx group on every boot

### DIFF
--- a/bluehost/files/php-tmpfiles.conf
+++ b/bluehost/files/php-tmpfiles.conf
@@ -1,0 +1,23 @@
+# /etc/tmpfiles.d/php.conf
+#
+# Overrides /usr/lib/tmpfiles.d/php.conf, which the php-fpm RPM ships owning
+# these directories root:apache. This deployment runs php-fpm as nginx:nginx
+# (see /etc/php-fpm.d/www.conf), not apache, so the vendor rule locks php-fpm
+# workers out of their own session/opcache/wsdlcache directories.
+#
+# systemd-tmpfiles-setup.service reapplies tmpfiles.d rules on EVERY boot, so
+# a host-side chgrp alone only survives until the next reboot — it silently
+# broke login after the first reboot since initial setup (issue #86: every
+# login POST bounced back to the sign-in page with no visible error, because
+# PHP could not open its own session files).
+#
+# A same-named file under /etc/tmpfiles.d fully replaces the /usr/lib one
+# rather than merging with it, so every line from the vendor file is repeated
+# here — only the group column changes, from apache to nginx. The log
+# directory line is unchanged: php-fpm's master process opens that log as
+# root before dropping privileges for workers, so it was never affected.
+d /var/lib/php           0755 root   root   -
+d /var/lib/php/opcache   0770 root   nginx  -
+d /var/lib/php/session   0770 root   nginx  -
+d /var/lib/php/wsdlcache 0770 root   nginx  -
+d /var/log/php-fpm       0770 apache root   -

--- a/bluehost/provision.sh
+++ b/bluehost/provision.sh
@@ -397,9 +397,16 @@ sed -i 's/^group = .*/group = nginx/'        /etc/php-fpm.d/www.conf
 sed -i 's/^listen.owner = .*/listen.owner = nginx/' /etc/php-fpm.d/www.conf
 sed -i 's/^listen.group = .*/listen.group = nginx/' /etc/php-fpm.d/www.conf
 
-mkdir -p /var/lib/php/session
-chown -R nginx:nginx /var/lib/php/session
-chmod 700 /var/lib/php/session
+# NOT a one-time mkdir+chown: /usr/lib/tmpfiles.d/php.conf ships these
+# directories owned root:apache, and systemd-tmpfiles-setup.service reapplies
+# that on EVERY boot, not just at package-install time. A chown here alone
+# looks fixed until the next reboot silently undoes it — which is exactly
+# what happened in issue #86 (every login bounced back to the sign-in page
+# with no error, because php-fpm workers running as nginx could no longer
+# open their own session files). Installing a same-named file under
+# /etc/tmpfiles.d fully replaces the vendor one rather than merging with it.
+install -m 0644 "$SCRIPT_DIR/files/php-tmpfiles.conf" /etc/tmpfiles.d/php.conf
+systemd-tmpfiles --create /etc/tmpfiles.d/php.conf
 
 # Process-manager sizing. Stock EL ships pm.max_children = 50, which against
 # the 512M memory_limit below is a promise this box cannot keep.


### PR DESCRIPTION
## Problem
`/var/lib/php/session` (and opcache/wsdlcache) ship owned `root:apache` via the OS package's `/usr/lib/tmpfiles.d/php.conf`. This deployment runs php-fpm as `nginx:nginx`, not `apache`. Someone had manually chgrp'd the session dir to `nginx` at some point after initial provisioning, letting logins work — but that fix lived only on the live host, not in any script.

On 2026-08-28, a VPS resize forced the box's first reboot since initial setup. `systemd-tmpfiles-setup.service` reapplied the vendor tmpfiles rule at boot, resetting the group back to `apache`, and every login silently failed: PHP could not open session files (`Permission denied`), so a successful login POST just bounced back to the sign-in page with no visible error.

## Fix
Add `/etc/tmpfiles.d/php.conf` (overrides the vendor file of the same name entirely, per systemd-tmpfiles precedence) pinning session/opcache/wsdlcache to group `nginx`, installed by `provision.sh` and applied immediately via `systemd-tmpfiles --create`. Survives every future reboot.

Applied live to unblock login immediately; this issue tracks making it permanent in the script.
