### PR TITLE
fix: raise chunk-cleanup stale threshold from 3h to 24h

### DIFF
--- a/bluehost/onevoice.env.example
+++ b/bluehost/onevoice.env.example
@@ -100,7 +100,10 @@ NEXTCLOUD_DATA_DIR="/var/www/nextcloud/data"   # used when OBJECT_STORE=local
 
 # Hours a WebDAV chunked-upload staging dir (data/<user>/uploads/<token>/) can
 # sit untouched before nextcloud-chunk-cleanup.timer deletes it. See issue #80.
-CHUNK_CLEANUP_STALE_HOURS="3"
+# Raised from 3 to 24 (#89) — large uploads on this connection can go hours
+# between chunk writes, and 3h risked deleting a still-active upload rather
+# than an abandoned one. Disk headroom isn't a concern (20% used, 80GB free).
+CHUNK_CLEANUP_STALE_HOURS="24"
 
 # ---------------------------------------------------------------------------
 # Backups (nextcloud-backup.timer, nightly restic run — see issue #83)


### PR DESCRIPTION
Fixes #89

Large uploads on this connection can take hours, and the 3h staleness window for the chunk-cleanup job (#80) risked deleting a still-active upload rather than an abandoned one. Bumped to 24h — disk headroom isn't a concern (20% used, 80GB free).

Already applied directly to the live server's `/etc/onevoice/onevoice.env` as an immediate mitigation; this PR lands the same value in `onevoice.env.example` so it isn't lost on the next reprovision.