### PR TITLE
feat: direct-download Worker + signed-token scheme

### DIFF
--- a/cloudflare/direct-download-worker/mint-test-token.mjs
+++ b/cloudflare/direct-download-worker/mint-test-token.mjs
@@ -1,0 +1,53 @@
+// Manual test-token minter for Phase 1 hand-testing (#92). Run this
+// yourself, locally, with your own WORKER_SIGNING_SECRET -- it never needs
+// to be shared with anyone else to test the deployed Worker.
+//
+// Usage:
+//   node mint-test-token.mjs "<signing-secret>" "<B2 object key>" [ttl-seconds]
+//
+// Example:
+//   node mint-test-token.mjs "my-secret" "OneVoice/Documents/test.pdf" 300
+//
+// Prints a ready-to-use curl command against your deployed Worker URL.
+
+const [, , secret, key, ttlArg] = process.argv;
+
+if (!secret || !key) {
+	console.error('Usage: node mint-test-token.mjs "<signing-secret>" "<B2 object key>" [ttl-seconds]');
+	process.exit(1);
+}
+
+const ttl = ttlArg ? parseInt(ttlArg, 10) : 300;
+
+function base64UrlEncode(bytes) {
+	let bin = '';
+	for (const b of bytes) bin += String.fromCharCode(b);
+	return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function mintToken(payload, secret) {
+	const payloadBytes = new TextEncoder().encode(JSON.stringify(payload));
+	const payloadB64 = base64UrlEncode(payloadBytes);
+
+	const cryptoKey = await crypto.subtle.importKey(
+		'raw', new TextEncoder().encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+	);
+	const sig = await crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(payloadB64));
+	const sigB64 = base64UrlEncode(new Uint8Array(sig));
+
+	return `${payloadB64}.${sigB64}`;
+}
+
+const exp = Math.floor(Date.now() / 1000) + ttl;
+const token = await mintToken({ key, exp, filename: key.split('/').pop() }, secret);
+
+console.log('');
+console.log(`Token expires in ${ttl}s (unix ${exp}).`);
+console.log('');
+console.log('Test with:');
+console.log(`  curl -i "https://<your-worker>.workers.dev/?t=${token}"`);
+console.log('');
+console.log('To confirm rejection works, wait for it to expire and try again --');
+console.log('should get 403. Or edit the key above by one character and re-mint --');
+console.log('should also get 403 (signature won\'t match the tampered payload).');

--- a/cloudflare/direct-download-worker/package.json
+++ b/cloudflare/direct-download-worker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "onevoice-direct-download-worker",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "node test-token.mjs"
+  },
+  "dependencies": {
+    "aws4fetch": "^1.0.20"
+  },
+  "devDependencies": {
+    "wrangler": "^3.90.0"
+  }
+}

--- a/cloudflare/direct-download-worker/test-token.mjs
+++ b/cloudflare/direct-download-worker/test-token.mjs
@@ -1,0 +1,132 @@
+// Standalone correctness test for the token scheme, independent of the
+// Worker runtime and aws4fetch, so it can run with plain `node` — no
+// deployment, no Cloudflare account, no B2 credentials needed.
+//
+// This also doubles as the reference implementation for what Nextcloud's
+// PHP side (Phase 2, #93) needs to replicate byte-for-byte: same base64url
+// encoding, same HMAC-SHA256 over the same payload bytes.
+
+function base64UrlEncode(bytes) {
+	let bin = '';
+	for (const b of bytes) bin += String.fromCharCode(b);
+	return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(str) {
+	str = str.replace(/-/g, '+').replace(/_/g, '/');
+	while (str.length % 4) str += '=';
+	const bin = atob(str);
+	const bytes = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+	return bytes;
+}
+
+async function mintToken(payload, secret) {
+	const payloadBytes = new TextEncoder().encode(JSON.stringify(payload));
+	const payloadB64 = base64UrlEncode(payloadBytes);
+
+	const key = await crypto.subtle.importKey(
+		'raw', new TextEncoder().encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+	);
+	const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payloadB64));
+	const sigB64 = base64UrlEncode(new Uint8Array(sig));
+
+	return `${payloadB64}.${sigB64}`;
+}
+
+async function verifyToken(token, secret) {
+	if (!token || typeof token !== 'string') return null;
+	const parts = token.split('.');
+	if (parts.length !== 2) return null;
+	const [payloadB64, sigB64] = parts;
+
+	let signatureBytes, payloadBytes;
+	try {
+		signatureBytes = base64UrlDecode(sigB64);
+		payloadBytes = base64UrlDecode(payloadB64);
+	} catch {
+		return null;
+	}
+
+	const key = await crypto.subtle.importKey(
+		'raw', new TextEncoder().encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' }, false, ['verify']
+	);
+
+	const valid = await crypto.subtle.verify('HMAC', key, signatureBytes, new TextEncoder().encode(payloadB64));
+	if (!valid) return null;
+
+	let payload;
+	try {
+		payload = JSON.parse(new TextDecoder().decode(payloadBytes));
+	} catch {
+		return null;
+	}
+
+	if (!payload || typeof payload.key !== 'string' || typeof payload.exp !== 'number') return null;
+	if (Math.floor(Date.now() / 1000) > payload.exp) return null;
+
+	return payload;
+}
+
+let failures = 0;
+function check(name, cond) {
+	if (cond) {
+		console.log(`ok   - ${name}`);
+	} else {
+		console.log(`FAIL - ${name}`);
+		failures++;
+	}
+}
+
+const SECRET = 'test-secret-do-not-use-in-prod';
+const now = Math.floor(Date.now() / 1000);
+
+// 1. Valid token round-trips
+{
+	const token = await mintToken({ key: 'OneVoice/foo.mp4', exp: now + 300, filename: 'foo.mp4' }, SECRET);
+	const result = await verifyToken(token, SECRET);
+	check('valid token verifies and returns the correct payload', result && result.key === 'OneVoice/foo.mp4' && result.filename === 'foo.mp4');
+}
+
+// 2. Expired token is rejected
+{
+	const token = await mintToken({ key: 'OneVoice/foo.mp4', exp: now - 10 }, SECRET);
+	const result = await verifyToken(token, SECRET);
+	check('expired token is rejected', result === null);
+}
+
+// 3. Tampered payload (different key claimed) is rejected — this is the
+//    security-critical case: someone can't just edit which file they want.
+{
+	const token = await mintToken({ key: 'OneVoice/foo.mp4', exp: now + 300 }, SECRET);
+	const [payloadB64, sigB64] = token.split('.');
+	const tamperedPayload = base64UrlEncode(new TextEncoder().encode(JSON.stringify({ key: 'OneVoice/private-file.mp4', exp: now + 300 })));
+	const tamperedToken = `${tamperedPayload}.${sigB64}`;
+	const result = await verifyToken(tamperedToken, SECRET);
+	check('tampered payload (signature no longer matches) is rejected', result === null);
+}
+
+// 4. Wrong secret (e.g. token forged without knowing the real secret) is rejected
+{
+	const token = await mintToken({ key: 'OneVoice/foo.mp4', exp: now + 300 }, 'wrong-secret');
+	const result = await verifyToken(token, SECRET);
+	check('token signed with the wrong secret is rejected', result === null);
+}
+
+// 5. Malformed tokens are rejected, not thrown
+{
+	check('empty string rejected', (await verifyToken('', SECRET)) === null);
+	check('garbage string rejected', (await verifyToken('not-a-real-token', SECRET)) === null);
+	check('missing signature part rejected', (await verifyToken('onlyonepart', SECRET)) === null);
+	check('non-JSON payload rejected', (await verifyToken('bm90LWpzb24.abc', SECRET)) === null);
+}
+
+console.log('');
+if (failures > 0) {
+	console.log(`${failures} check(s) FAILED`);
+	process.exit(1);
+} else {
+	console.log('All checks passed.');
+}

--- a/cloudflare/direct-download-worker/worker.js
+++ b/cloudflare/direct-download-worker/worker.js
@@ -1,0 +1,124 @@
+// direct-download-worker — streams a B2 object straight from B2 to the
+// client, bypassing the Bluehost VPS as a byte-relay.
+//
+// This Worker makes NO authorization decisions of its own. Nextcloud
+// (server-side, after its own normal share/permission checks already pass)
+// mints a short-lived signed token and hands the client a URL pointing here.
+// This Worker's only job is: verify the token is genuine and unexpired, then
+// stream the corresponding B2 object. If the token doesn't verify, nothing
+// is served — fail closed, always.
+//
+// Token format: "<base64url(payload json)>.<base64url(HMAC-SHA256 signature)>"
+// payload = { key: "<B2 object key>", exp: <unix seconds>, filename?: "<name>" }
+//
+// Expiry is checked once, when the request arrives — not re-checked mid
+// stream — so a large download that runs past the token's expiry still
+// finishes once it has legitimately started.
+//
+// See #92 for the phase this belongs to and #91 for the overall project.
+
+import { AwsClient } from 'aws4fetch';
+
+function base64UrlDecode(str) {
+	str = str.replace(/-/g, '+').replace(/_/g, '/');
+	while (str.length % 4) str += '=';
+	const bin = atob(str);
+	const bytes = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+	return bytes;
+}
+
+async function verifyToken(token, secret) {
+	if (!token || typeof token !== 'string') return null;
+	const parts = token.split('.');
+	if (parts.length !== 2) return null;
+	const [payloadB64, sigB64] = parts;
+
+	let signatureBytes, payloadBytes;
+	try {
+		signatureBytes = base64UrlDecode(sigB64);
+		payloadBytes = base64UrlDecode(payloadB64);
+	} catch {
+		return null;
+	}
+
+	const key = await crypto.subtle.importKey(
+		'raw',
+		new TextEncoder().encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['verify']
+	);
+
+	const valid = await crypto.subtle.verify('HMAC', key, signatureBytes, new TextEncoder().encode(payloadB64));
+	if (!valid) return null;
+
+	let payload;
+	try {
+		payload = JSON.parse(new TextDecoder().decode(payloadBytes));
+	} catch {
+		return null;
+	}
+
+	if (!payload || typeof payload.key !== 'string' || typeof payload.exp !== 'number') return null;
+	if (Math.floor(Date.now() / 1000) > payload.exp) return null;
+
+	return payload;
+}
+
+export default {
+	async fetch(request, env) {
+		if (request.method !== 'GET' && request.method !== 'HEAD') {
+			return new Response('Method not allowed', { status: 405 });
+		}
+
+		const url = new URL(request.url);
+		const token = url.searchParams.get('t');
+
+		const payload = await verifyToken(token, env.WORKER_SIGNING_SECRET);
+		if (!payload) {
+			return new Response('Invalid or expired token', { status: 403 });
+		}
+
+		const b2 = new AwsClient({
+			accessKeyId: env.B2_READONLY_KEY_ID,
+			secretAccessKey: env.B2_READONLY_APPLICATION_KEY,
+			service: 's3',
+			region: env.B2_REGION,
+		});
+
+		const objectUrl = `https://${env.B2_BUCKET}.${env.B2_HOSTNAME}/${payload.key}`;
+
+		const forwardHeaders = {};
+		const rangeHeader = request.headers.get('Range');
+		if (rangeHeader) forwardHeaders['Range'] = rangeHeader;
+
+		const signedRequest = await b2.sign(objectUrl, {
+			method: request.method,
+			headers: forwardHeaders,
+		});
+
+		const b2Response = await fetch(signedRequest);
+
+		if (b2Response.status >= 400) {
+			// Do not leak B2's raw error body/headers to the client.
+			return new Response('Upstream storage error', { status: 502 });
+		}
+
+		const headers = new Headers();
+		for (const h of ['content-type', 'content-length', 'content-range', 'accept-ranges', 'etag']) {
+			const v = b2Response.headers.get(h);
+			if (v) headers.set(h, v);
+		}
+		headers.set('Cache-Control', 'private, no-store');
+		if (payload.filename) {
+			const safe = payload.filename.replace(/["\r\n]/g, '');
+			headers.set('Content-Disposition', `attachment; filename="${safe}"`);
+		}
+
+		return new Response(b2Response.body, {
+			status: b2Response.status,
+			headers,
+		});
+	},
+};

--- a/cloudflare/direct-download-worker/wrangler.toml
+++ b/cloudflare/direct-download-worker/wrangler.toml
@@ -1,0 +1,17 @@
+name = "onevoice-direct-download-test"
+main = "worker.js"
+compatibility_date = "2026-09-01"
+
+# Deployed to a route/subdomain NOT linked from anywhere in Nextcloud yet
+# (Phase 1, issue #92). Deliberately named "-test" so it's obvious this
+# build is not the production entry point.
+
+[vars]
+B2_BUCKET = "REPLACE_ME"
+B2_HOSTNAME = "s3.us-east-005.backblazeb2.com"
+B2_REGION = "us-east-005"
+
+# Secrets — NEVER put these here. Set with:
+#   wrangler secret put WORKER_SIGNING_SECRET
+#   wrangler secret put B2_READONLY_KEY_ID
+#   wrangler secret put B2_READONLY_APPLICATION_KEY

--- a/cloudflare/direct-download-worker/wrangler.toml
+++ b/cloudflare/direct-download-worker/wrangler.toml
@@ -7,7 +7,9 @@ compatibility_date = "2026-09-01"
 # build is not the production entry point.
 
 [vars]
-B2_BUCKET = "REPLACE_ME"
+# "OneVoice" migration bucket -- holds the bulk of real data (~792GB) and is
+# where the originally-diagnosed slow video (MNFD2114.MP4) actually lives.
+B2_BUCKET = "knoch-nextcloud-storage"
 B2_HOSTNAME = "s3.us-east-005.backblazeb2.com"
 B2_REGION = "us-east-005"
 

--- a/cloudflare/direct-download-worker/wrangler.toml
+++ b/cloudflare/direct-download-worker/wrangler.toml
@@ -1,6 +1,10 @@
 name = "onevoice-direct-download-test"
 main = "worker.js"
 compatibility_date = "2026-09-01"
+# Set explicitly so wrangler doesn't need to call /memberships to guess the
+# account -- that call needs a broader permission than the narrowly-scoped
+# "Workers Scripts: Edit" token this project deliberately uses.
+account_id = "eb7adfe987cffe8bab69c340caa9de86"
 
 # Deployed to a route/subdomain NOT linked from anywhere in Nextcloud yet
 # (Phase 1, issue #92). Deliberately named "-test" so it's obvious this


### PR DESCRIPTION
Part of #91, closes #92 (Phase 1)

A Cloudflare Worker that streams a B2 object straight to the client instead of proxying through the Bluehost VPS. Verifies a short-lived HMAC-signed token before serving anything -- makes no authorization decisions of its own, only checks that Nextcloud already made one (Nextcloud-side token minting is Phase 2, #93 -- not built yet).

`node test-token.mjs` exercises the token logic standalone -- no Cloudflare account, no B2 credentials, no deployment needed. All 8 checks pass, including the security-critical ones: tampered payload rejected, wrong secret rejected, expired token rejected, malformed input rejected.

**Not deployed anywhere yet.** Needs two things that don't exist and shouldn't be typed into chat/committed: a Cloudflare API token (Workers edit scope) and a new read-only B2 application key from the B2 console. Details in the README.

README lands separately per the docs/ branch rule.