### PR TITLE
feat: per-user allowlist for staged rollout

### DIFF
--- a/nextcloud-app/direct_download/lib/Dav/DirectDownloadPlugin.php
+++ b/nextcloud-app/direct_download/lib/Dav/DirectDownloadPlugin.php
@@ -7,6 +7,7 @@ namespace OCA\DirectDownload\Dav;
 use OCA\DAV\Connector\Sabre\File as DavFile;
 use OCA\DirectDownload\Service\TokenService;
 use OCA\Files_External\Lib\Storage\AmazonS3;
+use OCP\IUserSession;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
@@ -20,9 +21,10 @@ use Sabre\HTTP\ResponseInterface;
  *
  * Deliberately conservative: falls through to Sabre's normal GET handling
  * (returns true, does nothing) unless EVERY condition is met -- mobile
- * traffic, non-file nodes, non-B2-backed storage, and a missing/disabled
- * config all fall through safely to the existing, working proxy path.
- * Never redirects to a URL that couldn't be minted.
+ * traffic, non-file nodes, non-B2-backed storage, a missing/disabled
+ * config, and a user not yet on the staged-rollout allowlist (#94) all
+ * fall through safely to the existing, working proxy path. Never
+ * redirects to a URL that couldn't be minted.
  *
  * Hook pattern (event name, priority 90, node-from-path extraction) is
  * modeled directly on Nextcloud core's own ViewOnlyPlugin
@@ -34,6 +36,7 @@ class DirectDownloadPlugin extends ServerPlugin {
 
 	public function __construct(
 		private TokenService $tokenService,
+		private IUserSession $userSession,
 	) {
 	}
 
@@ -55,6 +58,13 @@ class DirectDownloadPlugin extends ServerPlugin {
 
 		$userAgent = $request->getHeader('User-Agent') ?? '';
 		if ($this->isMobileApp($userAgent)) {
+			return true;
+		}
+
+		$user = $this->userSession->getUser();
+		if ($user === null || !$this->tokenService->isUserAllowed($user->getUID())) {
+			// Staged-rollout allowlist (#94) -- fails closed. No user, or a
+			// user not yet opted in, gets the normal proxy path.
 			return true;
 		}
 

--- a/nextcloud-app/direct_download/lib/Service/TokenService.php
+++ b/nextcloud-app/direct_download/lib/Service/TokenService.php
@@ -27,6 +27,26 @@ class TokenService {
 		return $this->config->getAppValue('direct_download', 'redirect_enabled', 'false') === 'true';
 	}
 
+	/**
+	 * Staged-rollout allowlist (#94). Deliberately fail-closed: an unset or
+	 * empty value means NO ONE is eligible, even if redirect_enabled=true --
+	 * an admin must explicitly opt users in. A comma-separated list of
+	 * usernames restricts to just those accounts (the test-account stage);
+	 * the literal value "*" means everyone (the final, fully-rolled-out
+	 * stage). Mobile stays excluded by User-Agent regardless of this list.
+	 */
+	public function isUserAllowed(string $uid): bool {
+		$raw = trim($this->config->getAppValue('direct_download', 'redirect_allowed_users', ''));
+		if ($raw === '') {
+			return false;
+		}
+		if ($raw === '*') {
+			return true;
+		}
+		$allowed = array_map('trim', explode(',', $raw));
+		return in_array($uid, $allowed, true);
+	}
+
 	public function getWorkerBaseUrl(): ?string {
 		$url = $this->config->getAppValue('direct_download', 'worker_base_url', '');
 		return $url !== '' ? $url : null;

--- a/nextcloud-app/direct_download/tests/test-allowlist-logic.php
+++ b/nextcloud-app/direct_download/tests/test-allowlist-logic.php
@@ -1,0 +1,42 @@
+<?php
+// Standalone test of the allowlist parsing logic (mirrors
+// TokenService::isUserAllowed exactly) -- fail-closed semantics for the
+// staged rollout (#94): unset/empty means no one, "*" means everyone,
+// otherwise a comma-separated list of exact usernames.
+
+function isUserAllowed(string $raw, string $uid): bool {
+	$raw = trim($raw);
+	if ($raw === '') {
+		return false;
+	}
+	if ($raw === '*') {
+		return true;
+	}
+	$allowed = array_map('trim', explode(',', $raw));
+	return in_array($uid, $allowed, true);
+}
+
+$cases = [
+	['', 'admin', false, 'unset/empty config -- fail closed, no one allowed'],
+	['   ', 'admin', false, 'whitespace-only config -- also fail closed'],
+	['*', 'admin', true, 'wildcard allows anyone'],
+	['*', 'literally-anyone', true, 'wildcard allows anyone, not just known users'],
+	['admin', 'admin', true, 'exact single-user match'],
+	['admin', 'eayanwale', false, 'not in a single-user list'],
+	['admin,eayanwale,dcole', 'eayanwale', true, 'match within a comma list'],
+	['admin, eayanwale , dcole', 'eayanwale', true, 'whitespace around list entries is trimmed'],
+	['admin,eayanwale', 'admi', false, 'must be exact match, not a prefix'],
+	['admino', 'admin', false, 'must be exact match, not a substring'],
+];
+
+$failures = 0;
+foreach ($cases as [$raw, $uid, $expected, $label]) {
+	$actual = isUserAllowed($raw, $uid);
+	$status = $actual === $expected ? 'ok  ' : 'FAIL';
+	if ($actual !== $expected) $failures++;
+	echo "{$status} - {$label}: isUserAllowed(\"{$raw}\", \"{$uid}\") = " . ($actual ? 'true' : 'false') . "\n";
+}
+
+echo "\n";
+echo $failures > 0 ? "{$failures} check(s) FAILED\n" : "All checks passed.\n";
+exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
Part of #91, addresses #94 (Phase 3, stage 1)

Targets feat/93-nextcloud-redirect (not dev) since this builds directly on the still-open #98 -- keeps this diff to just the incremental allowlist change rather than duplicating everything from Phase 2.

Phase 2's mechanism was all-or-nothing: `redirect_enabled=true` meant every non-mobile user immediately got redirected. Real staged rollout needs per-user scoping. Adds `redirect_allowed_users`:
- unset/empty: fail closed, no one eligible (even with the master flag on)
- comma-separated usernames: just those accounts (test stage)
- `*`: everyone (final rollout stage)

10/10 standalone logic checks pass. Deployed and validated on production: currently live with `redirect_allowed_users=admin` -- confirmed working `302` for admin, zero warnings/errors over a 60s real-traffic window (everyone else unaffected).